### PR TITLE
error message (cosmetic) change proposal

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -50,6 +50,9 @@ func (c *cmdGroup) init() error {
 
 func (c *cmdGroup) parse(context *ParseContext) (selected []string, _ error) {
 	token := context.Peek()
+	if token.IsEOF() {
+		return nil, fmt.Errorf("expected command but none was specified")
+	}
 	if token.Type != TokenArg {
 		return nil, fmt.Errorf("expected command but got '%s'", token)
 	}

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -6,6 +6,14 @@ import (
 	"testing"
 )
 
+func TestCommandMissing(t *testing.T) {
+	app := New("app", "")
+	app.Command("a", "")
+	context := Tokenize([]string{})
+	_, err := app.parse(context)
+	assert.EqualError(t, err, "expected command but none was specified")
+}
+
 func TestNestedCommands(t *testing.T) {
 	app := New("app", "")
 	sub1 := app.Command("sub1", "")


### PR DESCRIPTION
According to

https://github.com/alecthomas/kingpin/blob/67522b6e0c62bf84ae2b0606b4067dd8ab19492f/cmd.go#L54

when no command is specified the error `expected command but got '<EOL>'` is returned.
Since I am presenting the error message as-is to the user, I find it rather "too low-level".
Therefore I would like to propose the change of that message to something else like `expected command but none was specified`, or `no command was specified`, or even `a command is required but none was specified` or something like this.
What do you think?
