### PR TITLE
Adds a failing test for short flags of subcommand not being recognized bug

### DIFF
--- a/cmd_test.go
+++ b/cmd_test.go
@@ -37,3 +37,19 @@ func TestNestedCommandsWithArgs(t *testing.T) {
 	assert.Equal(t, "c", *a)
 	assert.Equal(t, "d", *b)
 }
+
+func TestNestedCommandsWithFlags(t *testing.T) {
+	app := New("app", "")
+	cmd := app.Command("a", "").Command("b", "")
+	a := cmd.Flag("aaa", "").Short('a').String()
+	b := cmd.Flag("bbb", "").Short('b').String()
+	err := app.init()
+	assert.NoError(t, err)
+	context := Tokenize([]string{"a", "b", "--aaa", "x", "-b", "x"})
+	selected, err := app.parse(context)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(context.Tokens))
+	assert.Equal(t, "a b", selected)
+	assert.Equal(t, "x", *a)
+	assert.Equal(t, "x", *b)
+}


### PR DESCRIPTION
When setting up a short flag of a nested subcommand, the flag is recognized (when parsing a command line) if used in its long form but not recognized in its short form.

This PR contains only the failing test.
