### PR TITLE
Fix edge case of two column alignment

### DIFF
--- a/usage.go
+++ b/usage.go
@@ -29,7 +29,7 @@ func formatTwoColumns(w io.Writer, indent, padding, width int, rows [][2]string)
 		doc.ToText(buf, row[1], "", preIndent, width-s-padding-indent)
 		lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
 		fmt.Fprintf(w, "%s%-*s%*s", indentStr, s, row[0], padding, "")
-		if len(row[0]) > 20 {
+		if len(row[0]) >= 20 {
 			fmt.Fprintf(w, "\n%s%s", indentStr, offsetStr)
 		}
 		fmt.Fprintf(w, "%s\n", lines[0])

--- a/usage_test.go
+++ b/usage_test.go
@@ -2,6 +2,8 @@ package kingpin
 
 import (
 	"bytes"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,6 +20,20 @@ func TestFormatTwoColumns(t *testing.T) {
            something
            that is
            cool.
+`
+	assert.Equal(t, expected, buf.String())
+}
+
+func TestFormatTwoColumnsWide(t *testing.T) {
+	samples := [][2]string{
+		{strings.Repeat("x", 19), "19 chars"},
+		{strings.Repeat("x", 20), "20 chars"}}
+	buf := bytes.NewBuffer(nil)
+	formatTwoColumns(buf, 0, 0, 200, samples)
+	fmt.Println(buf.String())
+	expected := `xxxxxxxxxxxxxxxxxxx19 chars
+xxxxxxxxxxxxxxxxxxxx
+                   20 chars
 `
 	assert.Equal(t, expected, buf.String())
 }


### PR DESCRIPTION
In the current implementation, when the first column has exactly 20 chars, then the second column is offset 1 character to the right.

This PR introduces a failing test for the case and fixes the problem.
