### PR TITLE
COLUMNS overrides fd width

### DIFF
--- a/guesswidth_unix.go
+++ b/guesswidth_unix.go
@@ -5,11 +5,21 @@ package kingpin
 import (
 	"io"
 	"os"
+	"strconv"
 	"syscall"
 	"unsafe"
 )
 
 func guessWidth(w io.Writer) int {
+	// check if COLUMNS env is set to comply with
+	// http://pubs.opengroup.org/onlinepubs/009604499/basedefs/xbd_chap08.html
+	cols_str := os.Getenv("COLUMNS")
+	if cols_str != "" {
+		if cols, err := strconv.Atoi(cols_str); err == nil {
+			return cols
+		}
+	}
+
 	if t, ok := w.(*os.File); ok {
 		fd := t.Fd()
 		var dimensions [4]uint16


### PR DESCRIPTION
* guesswidth_unix.go: Check the env to see if the fd width should be
  overridden with the COLUMNS var

Signed-off-by: Jeff Mickey <j@codemac.net>