### PR TITLE
Support for flags defined with a pattern (regexp)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - Support for required flags and required positional arguments
 - Callbacks per command, flag and argument.
 - Help output that isn't as ugly as sin.
+- Support for flags defined with a pattern (regexp)
 
 ## Versions
 

--- a/global.go
+++ b/global.go
@@ -20,6 +20,11 @@ func Flag(name, help string) *FlagClause {
 	return CommandLine.Flag(name, help)
 }
 
+// FlagPattern adds a new flag pattern to the default parser.
+func FlagPattern(regex, help string) *FlagClause {
+	return CommandLine.FlagPattern(regex, help)
+}
+
 // Arg adds a new argument to the top-level of the default parser.
 func Arg(name, help string) *ArgClause {
 	return CommandLine.Arg(name, help)


### PR DESCRIPTION
This PR adds the ability to define flags using a regular expression, for example:
```
kingpin.FlagPattern(`root\.(\d+).(name|value)`, "Specify value at given path")
```
Any capture defined in the pattern can be retrieved via the new Capture parser, given this:
```
var pos []string
vals := kingpin.FlagPattern(`matrix-(\d+)-(\d+)`, "Specify value for entry in matrix col i, row j").Capture(&pos).Strings()
```
passing the command line flags `--matrix-0-0=foo --matrix-0-1=bar` will result in:
```
pos == []string{"0", "0", "0", "1"} 
vals == []string{"foo", "bar"}
```