### PR TITLE
Added OptionsFirst - the ability to force option to come before all positional arguments

### DIFF
--- a/app.go
+++ b/app.go
@@ -35,6 +35,7 @@ type Application struct {
 	preAction     Action
 	validator     ApplicationValidator
 	terminate     func(status int) // See Terminate()
+	optionsFirst  bool             // Force options to be before positional arguments
 }
 
 // New creates a new Kingpin application instance.
@@ -223,6 +224,13 @@ func (a *Application) PreAction(action Action) *Application {
 // Command adds a new top-level command.
 func (a *Application) Command(name, help string) *CmdClause {
 	return a.addCommand(name, help)
+}
+
+// Options first forces options to come before positional arguments
+// That is after the first positional argument is seen, all the next arguments are not handled as flags
+func (a *Application) OptionsFirst() *Application {
+	a.optionsFirst = true
+	return a
 }
 
 func (a *Application) init() error {

--- a/app.go
+++ b/app.go
@@ -24,18 +24,18 @@ type Application struct {
 	*flagGroup
 	*argGroup
 	*cmdGroup
-	initialized   bool
-	Name          string
-	Help          string
-	author        string
-	version       string
-	writer        io.Writer // Destination for usage and errors.
-	usageTemplate string
-	action        Action
-	preAction     Action
-	validator     ApplicationValidator
-	terminate     func(status int) // See Terminate()
-	optionsFirst  bool             // Force options to be before positional arguments
+	initialized    bool
+	Name           string
+	Help           string
+	author         string
+	version        string
+	writer         io.Writer // Destination for usage and errors.
+	usageTemplate  string
+	action         Action
+	preAction      Action
+	validator      ApplicationValidator
+	terminate      func(status int) // See Terminate()
+	noInterspersed bool             // can flags be interspersed with args (or must they come first)
 }
 
 // New creates a new Kingpin application instance.
@@ -226,10 +226,11 @@ func (a *Application) Command(name, help string) *CmdClause {
 	return a.addCommand(name, help)
 }
 
-// Options first forces options to come before positional arguments
-// That is after the first positional argument is seen, all the next arguments are not handled as flags
-func (a *Application) OptionsFirst() *Application {
-	a.optionsFirst = true
+// Interspersed control if flags can be interspersed with positional arguments
+//
+// true (the default) means that they can, false means that all the flags must appear before the first positional arguments.
+func (a *Application) Interspersed(interspersed bool) *Application {
+	a.noInterspersed = !interspersed
 	return a
 }
 

--- a/app_test.go
+++ b/app_test.go
@@ -160,3 +160,29 @@ func TestSubCommandRequired(t *testing.T) {
 	_, err := app.Parse([]string{"c0"})
 	assert.Error(t, err)
 }
+
+func TestOptionsFirstWith(t *testing.T) {
+	app := New("test", "help").OptionsFirst()
+	a1 := app.Arg("a1", "").String()
+	a2 := app.Arg("a2", "").String()
+	f1 := app.Flag("flag", "").String()
+
+	_, err := app.Parse([]string{"a1", "--flag=flag"})
+	assert.NoError(t, err)
+	assert.Equal(t, "a1", *a1)
+	assert.Equal(t, "--flag=flag", *a2)
+	assert.Equal(t, "", *f1)
+}
+
+func TestOptionsFirstWithout(t *testing.T) {
+	app := New("test", "help")
+	a1 := app.Arg("a1", "").String()
+	a2 := app.Arg("a2", "").String()
+	f1 := app.Flag("flag", "").String()
+
+	_, err := app.Parse([]string{"a1", "--flag=flag"})
+	assert.NoError(t, err)
+	assert.Equal(t, "a1", *a1)
+	assert.Equal(t, "", *a2)
+	assert.Equal(t, "flag", *f1)
+}

--- a/app_test.go
+++ b/app_test.go
@@ -161,8 +161,8 @@ func TestSubCommandRequired(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestOptionsFirstWith(t *testing.T) {
-	app := New("test", "help").OptionsFirst()
+func TestInterspersedFalse(t *testing.T) {
+	app := New("test", "help").Interspersed(false)
 	a1 := app.Arg("a1", "").String()
 	a2 := app.Arg("a2", "").String()
 	f1 := app.Flag("flag", "").String()
@@ -174,15 +174,24 @@ func TestOptionsFirstWith(t *testing.T) {
 	assert.Equal(t, "", *f1)
 }
 
-func TestOptionsFirstWithout(t *testing.T) {
-	app := New("test", "help")
-	a1 := app.Arg("a1", "").String()
-	a2 := app.Arg("a2", "").String()
-	f1 := app.Flag("flag", "").String()
+func TestInterspersedTrue(t *testing.T) {
+	// test once with the default value and once with explicit true
+	for i := 0; i < 2; i++ {
+		app := New("test", "help")
+		if i != 0 {
+			t.Log("Setting explicit")
+			app.Interspersed(true)
+		} else {
+			t.Log("Using default")
+		}
+		a1 := app.Arg("a1", "").String()
+		a2 := app.Arg("a2", "").String()
+		f1 := app.Flag("flag", "").String()
 
-	_, err := app.Parse([]string{"a1", "--flag=flag"})
-	assert.NoError(t, err)
-	assert.Equal(t, "a1", *a1)
-	assert.Equal(t, "", *a2)
-	assert.Equal(t, "flag", *f1)
+		_, err := app.Parse([]string{"a1", "--flag=flag"})
+		assert.NoError(t, err)
+		assert.Equal(t, "a1", *a1)
+		assert.Equal(t, "", *a2)
+		assert.Equal(t, "flag", *f1)
+	}
 }

--- a/parser.go
+++ b/parser.go
@@ -303,7 +303,7 @@ loop:
 				cmds = cmd.cmdGroup
 				context.Next()
 			} else if context.arguments.have() {
-				if app.optionsFirst {
+				if app.noInterspersed {
 					// no more flags
 					context.argsOnly = true
 				}

--- a/parser.go
+++ b/parser.go
@@ -303,6 +303,10 @@ loop:
 				cmds = cmd.cmdGroup
 				context.Next()
 			} else if context.arguments.have() {
+				if app.optionsFirst {
+					// no more flags
+					context.argsOnly = true
+				}
 				arg := context.nextArg()
 				if arg == nil {
 					break loop


### PR DESCRIPTION
Sometime there is a need to force flags to come before positional arguments.

My use case is that I have a run subcommand that basically run a script. Instead of forcing the end user to write something like:

app run script -- -x arg1 arg2...

With the use of OptionsFirst, the end user can simply write

app run script -x arg1 arg2...

The change is quite minimal and by default does nothing