### PR TITLE
Support hidden commands

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -67,6 +67,7 @@ type CmdClause struct {
 	action    Action
 	preAction Action
 	validator CmdClauseValidator
+	hidden    bool
 }
 
 func newCommand(app *Application, name, help string) *CmdClause {
@@ -126,4 +127,9 @@ func (c *CmdClause) init() error {
 		return err
 	}
 	return nil
+}
+
+func (c *CmdClause) Hidden() *CmdClause {
+	c.hidden = true
+	return c
 }

--- a/model.go
+++ b/model.go
@@ -119,6 +119,7 @@ type CmdModel struct {
 	Help        string
 	FullCommand string
 	Depth       int
+	Hidden      bool
 	*FlagGroupModel
 	*ArgGroupModel
 	*CmdGroupModel
@@ -207,6 +208,7 @@ func (c *CmdClause) Model() *CmdModel {
 		Name:           c.name,
 		Help:           c.help,
 		Depth:          depth,
+		Hidden:         c.hidden,
 		FullCommand:    c.FullCommand(),
 		FlagGroupModel: c.flagGroup.Model(),
 		ArgGroupModel:  c.argGroup.Model(),

--- a/templates.go
+++ b/templates.go
@@ -8,8 +8,10 @@ var DefaultUsageTemplate = `{{define "FormatCommand"}}\
 
 {{define "FormatCommands"}}\
 {{range .FlattenedCommands}}\
+{{if not .Hidden}}\
   {{.FullCommand}}{{template "FormatCommand" .}}
 {{.Help|Wrap 4}}
+{{end}}\
 {{end}}\
 {{end}}\
 
@@ -53,7 +55,9 @@ var CompactUsageTemplate = `{{define "FormatCommand"}}\
 
 {{define "FormatCommandList"}}\
 {{range .}}\
+{{if not .Hidden}}\
 {{.Depth|Indent}}{{.Name}}{{template "FormatCommand" .}}
+{{end}}\
 {{template "FormatCommandList" .Commands}}\
 {{end}}\
 {{end}}\
@@ -108,11 +112,13 @@ var ManPageTemplate = `{{define "FormatFlags"}}\
 
 {{define "FormatCommands"}}\
 {{range .FlattenedCommands}}\
+{{if not .Hidden}}\
 .SS
 \fB{{.FullCommand}}{{template "FormatCommand" .}}\\fR
 .PP
 {{.Help}}
 {{template "FormatFlags" .}}\
+{{end}}\
 {{end}}\
 {{end}}\
 
@@ -144,9 +150,11 @@ var LongHelpTemplate = `{{define "FormatCommand"}}\
 
 {{define "FormatCommands"}}\
 {{range .FlattenedCommands}}\
+{{if not .Hidden}}\
   {{.FullCommand}}{{template "FormatCommand" .}}
 {{.Help|Wrap 4}}
 {{with .Flags|FlagsToTwoColumns}}{{FormatTwoColumnsWithIndent . 4 2}}{{end}}
+{{end}}\
 {{end}}\
 {{end}}\
 

--- a/usage_test.go
+++ b/usage_test.go
@@ -37,3 +37,35 @@ xxxxxxxxxxxxxxxxxxxx
 `
 	assert.Equal(t, expected, buf.String())
 }
+
+func TestHiddenCommand(t *testing.T) {
+	templates := []struct{ name, template string }{
+		{"default", DefaultUsageTemplate},
+		{"Compact", CompactUsageTemplate},
+		{"Long", LongHelpTemplate},
+		{"Man", ManPageTemplate},
+	}
+
+	var buf bytes.Buffer
+	t.Log("1")
+
+	a := New("Test", "Test").Writer(&buf).Terminate(nil)
+	a.Command("visible", "visible")
+	a.Command("hidden", "hidden").Hidden()
+
+	for _, tp := range templates {
+		buf.Reset()
+		a.UsageTemplate(tp.template)
+		a.Parse(nil)
+		// a.Parse([]string{"--help"})
+		usage := buf.String()
+		t.Logf("Usage for %s is:\n%s\n", tp.name, usage)
+
+		if strings.Contains(usage, "hidden") {
+			t.Errorf("Error: Usage contain hidden (%s)", tp.name)
+		}
+		if !strings.Contains(usage, "visible") {
+			t.Errorf("Error; Usage does not contain visible (%s)", tp.name)
+		}
+	}
+}


### PR DESCRIPTION
Add support for hidden commands.

Note: I'm aware that if all the commands are hidden the usage may be ugly because I don't remove the commands header in this case. But I fail to see the meaning/need for that so I rather not complicate the code for no good reason.