### PR TITLE
Make --version ignore missing required flags/arguments

### DIFF
--- a/app.go
+++ b/app.go
@@ -386,6 +386,11 @@ func (a *Application) validateRequired(context *ParseContext) error {
 	flagElements := map[string]*ParseElement{}
 	for _, element := range context.Elements {
 		if flag, ok := element.Clause.(*FlagClause); ok {
+			if flag.name == "version" {
+				// Short-circuit, no validation of required flags/arguments when
+				// --version is specified.
+				return nil
+			}
 			flagElements[flag.name] = element
 		}
 	}

--- a/app.go
+++ b/app.go
@@ -192,7 +192,7 @@ func (a *Application) findCommandFromContext(context *ParseContext) string {
 // Version adds a --version flag for displaying the application version.
 func (a *Application) Version(version string) *Application {
 	a.version = version
-	a.Flag("version", "Show application version.").Action(func(*ParseContext) error {
+	a.Flag("version", "Show application version.").PreAction(func(*ParseContext) error {
 		fmt.Fprintln(a.writer, version)
 		a.terminate(0)
 		return nil
@@ -386,11 +386,6 @@ func (a *Application) validateRequired(context *ParseContext) error {
 	flagElements := map[string]*ParseElement{}
 	for _, element := range context.Elements {
 		if flag, ok := element.Clause.(*FlagClause); ok {
-			if flag.name == "version" {
-				// Short-circuit, no validation of required flags/arguments when
-				// --version is specified.
-				return nil
-			}
 			flagElements[flag.name] = element
 		}
 	}

--- a/args_test.go
+++ b/args_test.go
@@ -24,6 +24,7 @@ func TestArgRemainderErrorsWhenNotLast(t *testing.T) {
 
 func TestArgMultipleRequired(t *testing.T) {
 	app := New("test", "")
+	app.Version("0.0.0")
 	app.Arg("a", "").Required().String()
 	app.Arg("b", "").Required().String()
 
@@ -32,6 +33,8 @@ func TestArgMultipleRequired(t *testing.T) {
 	_, err = app.Parse([]string{"A"})
 	assert.Error(t, err)
 	_, err = app.Parse([]string{"A", "B"})
+	assert.NoError(t, err)
+	_, err = app.Parse([]string{"--version"})
 	assert.NoError(t, err)
 }
 

--- a/flags_test.go
+++ b/flags_test.go
@@ -46,11 +46,14 @@ func TestInvalidFlagDefaultCanBeOverridden(t *testing.T) {
 
 func TestRequiredFlag(t *testing.T) {
 	app := New("test", "")
+	app.Version("0.0.0")
 	app.Flag("a", "").Required().Bool()
 	_, err := app.Parse([]string{"--a"})
 	assert.NoError(t, err)
 	_, err = app.Parse([]string{})
 	assert.Error(t, err)
+	_, err = app.Parse([]string{"--version"})
+	assert.NoError(t, err)
 }
 
 func TestShortFlag(t *testing.T) {


### PR DESCRIPTION
At the moment, if you register the application version (with `app.Version(<version>)`) but also register required flags/args, `--version` does not work on its own. Instead, it will complain that required flags/arguments are not provided.

From an end-user perspective, it doesn't make sense to have to provide these just to display the version, because it will just ignore them anyway (all it does is print the version and exit).

This PR ensures `--version` works even in the presence of required arguments.