### PR TITLE
flag: handle explicit --no-something boolean flags

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -68,13 +68,18 @@ loop:
 
 			name := token.Value
 			if token.Type == TokenLong {
-				if strings.HasPrefix(name, "no-") {
-					name = name[3:]
-					invert = true
-				}
 				flag, ok = f.long[name]
 				if !ok {
-					return nil, fmt.Errorf("unknown long flag '%s'", flagToken)
+					if strings.HasPrefix(name, "no-") {
+						name = name[3:]
+					} else {
+						name = "no-" + name
+					}
+					invert = true
+					flag, ok = f.long[name]
+					if !ok {
+						return nil, fmt.Errorf("unknown long flag '%s'", flagToken)
+					}
 				}
 			} else {
 				flag, ok = f.short[name]

--- a/flags_test.go
+++ b/flags_test.go
@@ -38,6 +38,20 @@ func TestNegateNonBool(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestExplicityNoBool(t *testing.T) {
+	app := New("test", "")
+	b := app.Flag("no-something", "").Bool()
+	_, err := app.Parse([]string{"--no-something"})
+	assert.NoError(t, err)
+	assert.True(t, *b)
+	_, err = app.Parse([]string{"--no-no-something"})
+	assert.NoError(t, err)
+	assert.False(t, *b)
+	_, err = app.Parse([]string{"--something"})
+	assert.NoError(t, err)
+	assert.False(t, *b)
+}
+
 func TestInvalidFlagDefaultCanBeOverridden(t *testing.T) {
 	app := New("test", "")
 	app.Flag("a", "").Default("invalid").Bool()

--- a/model.go
+++ b/model.go
@@ -21,7 +21,11 @@ func (f *FlagGroupModel) FlagSummary() string {
 		}
 		if flag.Required {
 			if flag.IsBoolFlag() {
-				out = append(out, fmt.Sprintf("--[no-]%s", flag.Name))
+				name := flag.Name
+				if strings.HasPrefix(name, "no-") {
+					name = name[3:]
+				}
+				out = append(out, fmt.Sprintf("--[no-]%s", name))
 			} else {
 				out = append(out, fmt.Sprintf("--%s=%s", flag.Name, flag.FormatPlaceHolder()))
 			}


### PR DESCRIPTION
Before the change, the parser unconditionally stripped leading "no-"
from boolean options, inverting their values at the same time. This was
breaking explicit "--no-something" flags since the following lookup
failed.

Now, it first checks the flag exists. If not, it either strips a "no-"
prefix or adds it before trying again. It means registering "--something"
implicitely registers "--something" and "--no-something" like before,
while registering "--no-something" now implicitely registers
"--no-something" and "--something".

I noticed some code was adjusting the help output for boolean flags to
reflect this. I tried to fix it but since there are no tests I might
have missed other cases involving templates.

Also, I do not know what happens upon flag collisions, for instance when
registering a boolean --no-something and a non-boolean --something. But
this was possible already.

Issue #54