### PR TITLE
Add optional automatic environment variable naming

### DIFF
--- a/app.go
+++ b/app.go
@@ -44,7 +44,6 @@ type Application struct {
 // New creates a new Kingpin application instance.
 func New(name, help string) *Application {
 	a := &Application{
-		flagGroup:     newFlagGroup(),
 		argGroup:      newArgGroup(),
 		Name:          name,
 		Help:          help,
@@ -52,6 +51,7 @@ func New(name, help string) *Application {
 		usageTemplate: DefaultUsageTemplate,
 		terminate:     os.Exit,
 	}
+	a.flagGroup = newFlagGroup(a)
 	a.cmdGroup = newCmdGroup(a)
 	a.HelpFlag = a.Flag("help", "Show context-sensitive help (also try --help-long and --help-man).")
 	a.HelpFlag.Bool()

--- a/cmd.go
+++ b/cmd.go
@@ -92,13 +92,13 @@ type CmdClause struct {
 
 func newCommand(app *Application, name, help string) *CmdClause {
 	c := &CmdClause{
-		flagGroup: newFlagGroup(),
-		argGroup:  newArgGroup(),
-		cmdGroup:  newCmdGroup(app),
-		app:       app,
-		name:      name,
-		help:      help,
+		argGroup: newArgGroup(),
+		cmdGroup: newCmdGroup(app),
+		app:      app,
+		name:     name,
+		help:     help,
 	}
+	c.flagGroup = newFlagGroup(app)
 	return c
 }
 

--- a/flags_test.go
+++ b/flags_test.go
@@ -18,7 +18,7 @@ func TestBool(t *testing.T) {
 }
 
 func TestNoBool(t *testing.T) {
-	fg := newFlagGroup()
+	fg := newFlagGroup(nil)
 	f := fg.Flag("b", "").Default("true")
 	b := f.Bool()
 	fg.init()
@@ -29,7 +29,7 @@ func TestNoBool(t *testing.T) {
 }
 
 func TestNegateNonBool(t *testing.T) {
-	fg := newFlagGroup()
+	fg := newFlagGroup(nil)
 	f := fg.Flag("b", "")
 	f.Int()
 	fg.init()

--- a/parser.go
+++ b/parser.go
@@ -125,7 +125,7 @@ func tokenize(args []string, ignoreDefault bool) *ParseContext {
 	return &ParseContext{
 		ignoreDefault: ignoreDefault,
 		args:          args,
-		flags:         newFlagGroup(),
+		flags:         newFlagGroup(nil),
 		arguments:     newArgGroup(),
 	}
 }


### PR DESCRIPTION
I've found my self repeating this pattern in every new program I create:

```go
app = kingpin.New("progname", "...")
foo  = app.Flag("foo", "...").Default("x").OverrideDefaultFromEnvar("PROGNAME_FOO").String()
bar  = app.Flag("bar", "...").Default("x").OverrideDefaultFromEnvar("PROGNAME_BAR").String()
```

Repeating the program name and the flag name in the OverrideDefaultFromEnvar call quickly becomes a PITA, so in every new program I end up doing:

```go
const appname = "progname"
func env(s string) string {
  return string.Replace(strings.ToUpper(appname + "_" + s), "-", "_", -1)
}
app := kingpin.New(appname, "...")
foo  := app.Flag("foo", "...").Default("x").OverrideDefaultFromEnvar(env("foo")).String()
bar  := app.Flag("bar", "...").Default("x").OverrideDefaultFromEnvar(env("bar")).String()
```

Which is better but still boilerplate in every project.

So I propose to add a new OverrideDefaultFromEnv() flag mutator to automatically generate
the name of the environment variable as a function of the application name
and the flag name as above, so it becomes:

```go
app := kingpin.New("progname", "...")
foo  := app.Flag("foo", "...").Default("x").OverrideDefaultFromEnv().String()
bar  := app.Flag("bar", "...").Default("x").OverrideDefaultFromEnv().String()
```

And this is the working patch.