### PR TITLE
Update README (CommandLine.HelpFlag.Short part)

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,7 +494,7 @@ ips := IPList(kingpin.Arg("ips", "IP addresses to ping."))
 
 ### Supporting -h for help
 
-`kingpin.CommandLine.HelpFlag.Short('-h')`
+`kingpin.CommandLine.HelpFlag.Short('h')`
 
 ### Custom help
 


### PR DESCRIPTION
For this part of the README:

`kingpin.CommandLine.HelpFlag.Short('-h')`

go1.5 gives me: `illegal rune literal`

Compiled without errrors only this way:

`kingpin.CommandLine.HelpFlag.Short('h')`

Fixed corresponding part of the README.