### PR TITLE
Added support for regexp flags

### DIFF
--- a/flags_test.go
+++ b/flags_test.go
@@ -107,3 +107,14 @@ func TestRequiredWithEnvar(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 123, *flag)
 }
+
+func TestRegexp(t *testing.T) {
+	app := New("test", "")
+	flag := app.Flag("reg", "").Regexp()
+	_, err := app.Parse([]string{"--reg", "^abc$"})
+	assert.NoError(t, err)
+	assert.NotNil(t, *flag)
+	assert.Equal(t, "^abc$", (*flag).String())
+	assert.Regexp(t, *flag, "abc")
+	assert.NotRegexp(t, *flag, "abcd")
+}

--- a/parsers.go
+++ b/parsers.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"regexp"
 	"time"
 
 	"github.com/alecthomas/units"
@@ -209,4 +210,16 @@ func (p *parserMixin) Counter() (target *int) {
 
 func (p *parserMixin) CounterVar(target *int) {
 	p.SetValue(newCounterValue(target))
+}
+
+// Regexp
+func (p *parserMixin) Regexp() (target **regexp.Regexp) {
+	target = new(*regexp.Regexp)
+	p.RegexpVar(target)
+	return
+}
+
+// Regexp
+func (p *parserMixin) RegexpVar(target **regexp.Regexp) {
+	p.SetValue(newRegexpValue(target))
 }

--- a/values.go
+++ b/values.go
@@ -445,3 +445,32 @@ func (c *counterValue) Set(s string) error {
 func (c *counterValue) Get() interface{} { return (int)(*c) }
 func (c *counterValue) IsBoolFlag() bool { return true }
 func (c *counterValue) String() string   { return fmt.Sprintf("%d", *c) }
+
+// -- regexp.Regexp value
+type regexpValue struct {
+	r **regexp.Regexp
+}
+
+func newRegexpValue(r **regexp.Regexp) *regexpValue {
+	return &regexpValue{r}
+}
+
+func (r *regexpValue) Set(value string) error {
+	if re, err := regexp.Compile(value); err != nil {
+		return err
+	} else {
+		*r.r = re
+		return nil
+	}
+}
+
+func (r *regexpValue) Get() interface{} {
+	return (*regexp.Regexp)(*r.r)
+}
+
+func (r *regexpValue) String() string {
+	if *r.r == nil {
+		return "<nil>"
+	}
+	return (*r.r).String()
+}

--- a/values.json
+++ b/values.json
@@ -18,5 +18,6 @@
   {"name": "TCPAddr", "Type": "*net.TCPAddr", "plural": "TCPList", "no_value_parser": true},
   {"name": "ExistingFile", "Type": "string", "plural": "ExistingFiles", "no_value_parser": true},
   {"name": "ExistingDir", "Type": "string", "plural": "ExistingDirs", "no_value_parser": true},
-  {"name": "ExistingFileOrDir", "Type": "string", "plural": "ExistingFilesOrDirs", "no_value_parser": true}
+  {"name": "ExistingFileOrDir", "Type": "string", "plural": "ExistingFilesOrDirs", "no_value_parser": true},
+  {"name": "Regexp", "Type": "*regexp.Regexp", "plural": "RegexpList", "no_value_parser": true}
 ]

--- a/values_generated.go
+++ b/values_generated.go
@@ -3,6 +3,7 @@ package kingpin
 import (
 	"fmt"
 	"net"
+	"regexp"
 	"strconv"
 	"time"
 )
@@ -619,4 +620,15 @@ func (p *parserMixin) ExistingFilesOrDirs() (target *[]string) {
 
 func (p *parserMixin) ExistingFilesOrDirsVar(target *[]string) {
 	p.SetValue(newAccumulator(target, func(v interface{}) Value { return newExistingFileOrDirValue(v.(*string)) }))
+}
+
+// RegexpList accumulates *regexp.Regexp values into a slice.
+func (p *parserMixin) RegexpList() (target *[]*regexp.Regexp) {
+	target = new([]*regexp.Regexp)
+	p.RegexpListVar(target)
+	return
+}
+
+func (p *parserMixin) RegexpListVar(target *[]*regexp.Regexp) {
+	p.SetValue(newAccumulator(target, func(v interface{}) Value { return newRegexpValue(v.(**regexp.Regexp)) }))
 }


### PR DESCRIPTION
Added support and test for regular expressions as flag/argument values.

I didn't add the `RegexList*` family of functions since I didn't figure they'd be that useful. Can easily add to  `values.json` if desired.