### PR TITLE
Make code build in appengine

### DIFF
--- a/guesswidth_ae.go
+++ b/guesswidth_ae.go
@@ -1,0 +1,10 @@
+// +build appengine
+
+package kingpin
+
+import "io"
+
+func guessWidth(w io.Writer) int {
+	// No need to guess for appengine...
+	return 80
+}

--- a/guesswidth_unix.go
+++ b/guesswidth_unix.go
@@ -1,4 +1,4 @@
-// +build linux freebsd darwin dragonfly netbsd openbsd
+// +build !appengine,linux freebsd darwin dragonfly netbsd openbsd
 
 package kingpin
 


### PR DESCRIPTION
Add the proper build constraints to avoid the use of `syscall` when build is for appengine.