### PR TITLE
Added NetAddr flag type

### DIFF
--- a/flags_test.go
+++ b/flags_test.go
@@ -2,6 +2,7 @@ package kingpin
 
 import (
 	"io/ioutil"
+	"net"
 	"os"
 
 	"github.com/stretchr/testify/assert"
@@ -117,4 +118,22 @@ func TestRegexp(t *testing.T) {
 	assert.Equal(t, "^abc$", (*flag).String())
 	assert.Regexp(t, *flag, "abc")
 	assert.NotRegexp(t, *flag, "abcd")
+}
+
+func TestIPv4Addr(t *testing.T) {
+	app := New("test", "")
+	flag := app.Flag("addr", "").NetAddr()
+	_, err := app.Parse([]string{"--addr", net.IPv4(1, 2, 3, 4).String()})
+	assert.NoError(t, err)
+	assert.NotNil(t, *flag)
+	assert.Equal(t, net.IPv4(1, 2, 3, 4), *flag)
+}
+
+func TestIPv6Addr(t *testing.T) {
+	app := New("test", "")
+	flag := app.Flag("addr", "").NetAddr()
+	_, err := app.Parse([]string{"--addr", net.IPv6interfacelocalallnodes.String()})
+	assert.NoError(t, err)
+	assert.NotNil(t, *flag)
+	assert.Equal(t, net.IPv6interfacelocalallnodes, *flag)
 }

--- a/parsers.go
+++ b/parsers.go
@@ -223,3 +223,15 @@ func (p *parserMixin) Regexp() (target **regexp.Regexp) {
 func (p *parserMixin) RegexpVar(target **regexp.Regexp) {
 	p.SetValue(newRegexpValue(target))
 }
+
+// NetAddr
+func (p *parserMixin) NetAddr() (target *net.IP) {
+	target = new(net.IP)
+	p.NetAddrVar(target)
+	return
+}
+
+// NetAddr
+func (p *parserMixin) NetAddrVar(target *net.IP) {
+	p.SetValue(newNetAddrValue(target))
+}

--- a/values.go
+++ b/values.go
@@ -474,3 +474,36 @@ func (r *regexpValue) String() string {
 	}
 	return (*r.r).String()
 }
+
+// -- DNS-resolved net.IP value
+type netAddrValue struct {
+	r *net.IP
+}
+
+func newNetAddrValue(r *net.IP) *netAddrValue {
+	return &netAddrValue{r}
+}
+
+func (a *netAddrValue) Set(value string) error {
+	if ip := net.ParseIP(value); ip != nil {
+		*a.r = ip
+	} else {
+		if addr, err := net.ResolveIPAddr("ip", value); err != nil {
+			return err
+		} else {
+			*a.r = addr.IP
+		}
+	}
+	return nil
+}
+
+func (a *netAddrValue) Get() interface{} {
+	return (net.IP)(*a.r)
+}
+
+func (a *netAddrValue) String() string {
+	if *a.r == nil {
+		return "<nil>"
+	}
+	return (*a.r).String()
+}

--- a/values.json
+++ b/values.json
@@ -19,5 +19,6 @@
   {"name": "ExistingFile", "Type": "string", "plural": "ExistingFiles", "no_value_parser": true},
   {"name": "ExistingDir", "Type": "string", "plural": "ExistingDirs", "no_value_parser": true},
   {"name": "ExistingFileOrDir", "Type": "string", "plural": "ExistingFilesOrDirs", "no_value_parser": true},
-  {"name": "Regexp", "Type": "*regexp.Regexp", "plural": "RegexpList", "no_value_parser": true}
+  {"name": "Regexp", "Type": "*regexp.Regexp", "plural": "RegexpList", "no_value_parser": true},
+  {"name": "NetAddr", "Type": "net.IP", "plural": "NetAddrs", "no_value_parser": true}
 ]

--- a/values_generated.go
+++ b/values_generated.go
@@ -632,3 +632,14 @@ func (p *parserMixin) RegexpList() (target *[]*regexp.Regexp) {
 func (p *parserMixin) RegexpListVar(target *[]*regexp.Regexp) {
 	p.SetValue(newAccumulator(target, func(v interface{}) Value { return newRegexpValue(v.(**regexp.Regexp)) }))
 }
+
+// NetAddrs accumulates net.IP values into a slice.
+func (p *parserMixin) NetAddrs() (target *[]net.IP) {
+	target = new([]net.IP)
+	p.NetAddrsVar(target)
+	return
+}
+
+func (p *parserMixin) NetAddrsVar(target *[]net.IP) {
+	p.SetValue(newAccumulator(target, func(v interface{}) Value { return newNetAddrValue(v.(*net.IP)) }))
+}


### PR DESCRIPTION
This PR adds a `NetAddr` flag type which accepts a network address either in IP address form, or a DNS name.

`NetAddr` differs from `IP` because it accepts a DNS name, which it will then resolve using `net.ResolveIPAddr`.
`NetAddr` differs from `TCPAddr` because it does not accept a port number (and thus does not fail if one is provided, unlike `TCPAddr`)

[Simple test program](https://gist.github.com/zfjagann/2c292ad0ee2f9fb5fca1)