### PR TITLE
prefer user-defined env var value over application-hardcoded defaults

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -178,16 +178,6 @@ func newFlag(name, help string) *FlagClause {
 }
 
 func (f *FlagClause) setDefault() error {
-	// Set defaults, if any.
-	if len(f.defaultValues) > 0 {
-		for _, defaultValue := range f.defaultValues {
-			if err := f.value.Set(defaultValue); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
-
 	if !f.noEnvar && f.envar != "" {
 		if envarValue := os.Getenv(f.envar); envarValue != "" {
 			if v, ok := f.value.(repeatableFlag); !ok || !v.IsCumulative() {
@@ -205,6 +195,16 @@ func (f *FlagClause) setDefault() error {
 			}
 		}
 	}
+
+	if len(f.defaultValues) > 0 {
+		for _, defaultValue := range f.defaultValues {
+			if err := f.value.Set(defaultValue); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
 	return nil
 }
 

--- a/flags_test.go
+++ b/flags_test.go
@@ -157,6 +157,15 @@ func TestGetFlagAndOverrideDefault(t *testing.T) {
 	assert.Equal(t, "new", *a)
 }
 
+func TestEnvarOverrideDefault(t *testing.T) {
+	os.Setenv("TEST_ENVAR", "123")
+	app := newTestApp()
+	flag := app.Flag("t", "").Default("default").Envar("TEST_ENVAR").String()
+	_, err := app.Parse([]string{})
+	assert.NoError(t, err)
+	assert.Equal(t, "123", *flag)
+}
+
 func TestFlagMultipleValuesDefault(t *testing.T) {
 	app := newTestApp()
 	a := app.Flag("a", "").Default("default1", "default2").Strings()


### PR DESCRIPTION
My interpretation of the current [`.Envar()` contract](https://github.com/alecthomas/kingpin/blob/1895ce4fc0d6d75c01a7f1a728571250c7da6866/flags.go#L269-L270)... I can't think of a use case where `.Defaut()` should have precedence, otherwise it's just impossible to use env vars on a flag with a default value.