### PR TITLE
fix dangling "Subcommands:" on command help usage

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -37,7 +37,7 @@ Args:
 {{.Context.Args|ArgsToTwoColumns|FormatTwoColumns}}
 {{end}}\
 {{if .Context.SelectedCommand}}\
-{{if .Context.SelectedCommand.Commands}}\
+{{if len .Context.SelectedCommand.Commands}}\
 Subcommands:
 {{template "FormatCommands" .Context.SelectedCommand}}
 {{end}}\


### PR DESCRIPTION
With the current code, I see something like this on my command usage:
```
usage: tool command [<flags>]

Do Command

Flags:
      --help                     Show context-sensitive help (also try
                                 --help-long and --help-man).
      --version                  Show application version.

Subcommands:
```

Notice there are no subcommands but I see the header anyway.  Not sure if text/template changed the boolean truthiness of an empty slice, but adding a "len" in front of it seems to fix it:

```
usage: tool command [<flags>]

Do Command

Flags:
      --help                     Show context-sensitive help (also try
                                 --help-long and --help-man).
      --version                  Show application version.

```
