### PR TITLE
Add Bash Completion Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
   - [Default Values](#default-values)
   - [Place-holders in Help](#place-holders-in-help)
   - [Consuming all remaining arguments](#consuming-all-remaining-arguments)
+  - [Bash/ZSH Shell Completion](#bashzsh-shell-completion)
   - [Supporting -h for help](#supporting--h-for-help)
   - [Custom help](#custom-help)
 
@@ -507,6 +508,100 @@ And use it like so:
 ```go
 ips := IPList(kingpin.Arg("ips", "IP addresses to ping."))
 ```
+
+### Bash/ZSH Shell Completion
+
+By default, all flags and commands/subcommands generate completions 
+internally.
+
+Out of the box, CLI tools using kingpin should be able to take advantage 
+of completion hinting for flags and commands. By specifying 
+`--completion-bash` as the first argument, your CLI tool will show 
+possible subcommands. By ending your argv with `--`, hints for flags 
+will be shown.
+
+To allow your end users to take advantage you must package a 
+`/etc/bash_completion.d` script with your distribution (or the equivalent 
+for your target platform/shell). An alternative is to instruct your end 
+user to source a script from their `bash_profile` (or equivalent).
+
+Fortunately Kingpin makes it easy to generate or source a script for use
+with end users shells. `./yourtool --completion-script-bash` and 
+`./yourtool --completion-script-zsh` will generate these scripts for you.
+
+**Installation by Package**
+
+For the best user experience, you should bundle your pre-created 
+completion script with your CLI tool and install it inside 
+`/etc/bash_completion.d` (or equivalent). A good suggestion is to add 
+this as an automated step to your build pipeline, in the implementation 
+is improved for bug fixed.
+
+**Installation by `bash_profile`**
+
+Alternatively, instruct your users to add an additional statement to 
+their `bash_profile` (or equivalent):
+
+```
+eval "$(your-cli-tool --completion-script-bash)"
+```
+
+Or for ZSH
+
+```
+eval "$(your-cli-tool --completion-script-zsh)"
+```
+
+#### Additional API
+To provide more flexibility, a completion option API has been
+exposed for flags to allow user defined completion options, to extend
+completions further than just EnumVar/Enum. 
+
+
+**Provide Static Options**
+
+When using an `Enum` or `EnumVar`, users are limited to only the options 
+given. Maybe we wish to hint possible options to the user, but also 
+allow them to provide their own custom option. `HintOptions` gives
+this functionality to flags.
+
+```
+app := kingpin.New("completion", "My application with bash completion.")
+app.Flag("port", "Provide a port to connect to").
+    Required().
+    HintOptions("80", "443", "8080").
+    IntVar(&c.port)
+```
+
+**Provide Dynamic Options**
+Consider the case that you needed to read a local database or a file to 
+provide suggestions. You can dynamically generate the options
+
+```
+func listHosts(args []string) []string {
+  // Provide a dynamic list of hosts from a hosts file or otherwise
+  // for bash completion. In this example we simply return static slice.
+
+  // You could use this functionality to reach into a hosts file to provide
+  // completion for a list of known hosts.
+  return []string{"sshhost.example", "webhost.example", "ftphost.example"}
+}
+
+app := kingpin.New("completion", "My application with bash completion.")
+app.Flag("flag-1", "").HintAction(listHosts).String()
+```
+
+**EnumVar/Enum**
+When using `Enum` or `EnumVar`, any provided options will be automatically
+used for bash autocompletion. However, if you wish to provide a subset or 
+different options, you can use `HintOptions` or `HintAction` which will override
+the default completion options for `Enum`/`EnumVar`.
+
+
+**Examples**
+You can see an in depth example of the completion API within 
+`examples/completion/main.go`
+
 
 ### Supporting -h for help
 

--- a/cmd.go
+++ b/cmd.go
@@ -5,6 +5,71 @@ import (
 	"strings"
 )
 
+type cmdMixin struct {
+	*flagGroup
+	*argGroup
+	*cmdGroup
+	actionMixin
+}
+
+func (c *cmdMixin) CmdCompletion() []string {
+	rv := []string{}
+	if len(c.cmdGroup.commandOrder) > 0 {
+		// This command has subcommands. We should
+		// show these to the user.
+		for _, option := range c.cmdGroup.commandOrder {
+			rv = append(rv, option.name)
+		}
+	} else {
+		// No subcommands
+		rv = nil
+	}
+	return rv
+}
+
+func (c *cmdMixin) FlagCompletion(flagName string, flagValue string) (choices []string, flagMatch bool, optionMatch bool) {
+	// Check if flagName matches a known flag.
+	// If it does, show the options for the flag
+	// Otherwise, show all flags
+
+	options := []string{}
+
+	for _, flag := range c.flagGroup.flagOrder {
+		// Loop through each flag and determine if a match exists
+		if flag.name == flagName {
+			// User typed entire flag. Need to look for flag options.
+			options = flag.resolveCompletions()
+			if len(options) == 0 {
+				// No Options to Choose From, Assume Match.
+				return options, true, true
+			}
+
+			// Loop options to find if the user specified value matches
+			isPrefix := false
+			matched := false
+
+			for _, opt := range options {
+				if flagValue == opt {
+					matched = true
+				} else if strings.HasPrefix(opt, flagValue) {
+					isPrefix = true
+				}
+			}
+
+			// Matched Flag Directly
+			// Flag Value Not Prefixed, and Matched Directly
+			return options, true, !isPrefix && matched
+		}
+
+		if !flag.hidden {
+			options = append(options, "--"+flag.name)
+		}
+	}
+	// No Flag directly matched.
+	return options, false, false
+
+}
+
 type cmdGroup struct {
 	app          *Application
 	parent       *CmdClause
@@ -92,10 +157,7 @@ type CmdClauseValidator func(*CmdClause) error
 // A CmdClause is a single top-level command. It encapsulates a set of flags
 // and either subcommands or positional arguments.
 type CmdClause struct {
-	actionMixin
-	*flagGroup
-	*argGroup
-	*cmdGroup
+	cmdMixin
 	app       *Application
 	name      string
 	aliases   []string
@@ -107,13 +169,13 @@ type CmdClause struct {
 
 func newCommand(app *Application, name, help string) *CmdClause {
 	c := &CmdClause{
-		flagGroup: newFlagGroup(),
-		argGroup:  newArgGroup(),
-		cmdGroup:  newCmdGroup(app),
-		app:       app,
-		name:      name,
-		help:      help,
+		app:  app,
+		name: name,
+		help: help,
 	}
+	c.flagGroup = newFlagGroup()
+	c.argGroup = newArgGroup()
+	c.cmdGroup = newCmdGroup(app)
 	return c
 }
 

--- a/completions.go
+++ b/completions.go
@@ -1,0 +1,33 @@
+package kingpin
+
+// HintAction is a function type who is expected to return a slice of possible
+// command line arguments.
+type HintAction func() []string
+type completionsMixin struct {
+	hintActions        []HintAction
+	builtinHintActions []HintAction
+}
+
+func (a *completionsMixin) addHintAction(action HintAction) {
+	a.hintActions = append(a.hintActions, action)
+}
+
+// Allow adding of HintActions which are added internally, ie, EnumVar
+func (a *completionsMixin) addHintActionBuiltin(action HintAction) {
+	a.builtinHintActions = append(a.builtinHintActions, action)
+}
+
+func (a *completionsMixin) resolveCompletions() []string {
+	var hints []string
+
+	options := a.builtinHintActions
+	if len(a.hintActions) > 0 {
+		// User specified their own hintActions. Use those instead.
+		options = a.hintActions
+	}
+
+	for _, hintAction := range options {
+		hints = append(hints, hintAction()...)
+	}
+	return hints
+}

--- a/completions_test.go
+++ b/completions_test.go
@@ -1,0 +1,78 @@
+package kingpin
+
+import (
+	"testing"
+
+	"github.com/alecthomas/assert"
+)
+
+func TestResolveWithBuiltin(t *testing.T) {
+	a := completionsMixin{}
+
+	hintAction1 := func() []string {
+		return []string{"opt1", "opt2"}
+	}
+	hintAction2 := func() []string {
+		return []string{"opt3", "opt4"}
+	}
+
+	a.builtinHintActions = []HintAction{hintAction1, hintAction2}
+
+	args := a.resolveCompletions()
+	assert.Equal(t, []string{"opt1", "opt2", "opt3", "opt4"}, args)
+}
+
+func TestResolveWithUser(t *testing.T) {
+	a := completionsMixin{}
+	hintAction1 := func() []string {
+		return []string{"opt1", "opt2"}
+	}
+	hintAction2 := func() []string {
+		return []string{"opt3", "opt4"}
+	}
+
+	a.hintActions = []HintAction{hintAction1, hintAction2}
+
+	args := a.resolveCompletions()
+	assert.Equal(t, []string{"opt1", "opt2", "opt3", "opt4"}, args)
+}
+
+func TestResolveWithCombination(t *testing.T) {
+	a := completionsMixin{}
+	builtin := func() []string {
+		return []string{"opt1", "opt2"}
+	}
+	user := func() []string {
+		return []string{"opt3", "opt4"}
+	}
+
+	a.builtinHintActions = []HintAction{builtin}
+	a.hintActions = []HintAction{user}
+
+	args := a.resolveCompletions()
+	// User provided args take preference over builtin (enum-defined) args.
+	assert.Equal(t, []string{"opt3", "opt4"}, args)
+}
+
+func TestAddHintAction(t *testing.T) {
+	a := completionsMixin{}
+	hintFunc := func() []string {
+		return []string{"opt1", "opt2"}
+	}
+	a.addHintAction(hintFunc)
+
+	args := a.resolveCompletions()
+	assert.Equal(t, []string{"opt1", "opt2"}, args)
+}
+
+func TestAddHintActionBuiltin(t *testing.T) {
+	a := completionsMixin{}
+	hintFunc := func() []string {
+		return []string{"opt1", "opt2"}
+	}
+
+	a.addHintActionBuiltin(hintFunc)
+
+	args := a.resolveCompletions()
+	assert.Equal(t, []string{"opt1", "opt2"}, args)
+}

--- a/examples/completion/main.go
+++ b/examples/completion/main.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/alecthomas/kingpin"
+)
+
+func listHosts() []string {
+	// Provide a dynamic list of hosts from a hosts file or otherwise
+	// for bash completion. In this example we simply return static slice.
+
+	// You could use this functionality to reach into a hosts file to provide
+	// completion for a list of known hosts.
+	return []string{"sshhost.example", "webhost.example", "ftphost.example"}
+}
+
+type NetcatCommand struct {
+	hostName string
+	port     int
+	format   string
+}
+
+func (n *NetcatCommand) run(c *kingpin.ParseContext) error {
+	fmt.Printf("Would have run netcat to hostname %v, port %d, and output format %v\n", n.hostName, n.port, n.format)
+	return nil
+}
+
+func configureNetcatCommand(app *kingpin.Application) {
+	c := &NetcatCommand{}
+	nc := app.Command("nc", "Connect to a Host").Action(c.run)
+	nc.Flag("nop-flag", "Example of a flag with no options").Bool()
+
+	// You can provide hint options using a function to generate them
+	nc.Flag("host", "Provide a hostname to nc").
+		Required().
+		HintAction(listHosts).
+		StringVar(&c.hostName)
+
+	// You can provide hint options statically
+	nc.Flag("port", "Provide a port to connect to").
+		Required().
+		HintOptions("80", "443", "8080").
+		IntVar(&c.port)
+
+	// Enum/EnumVar options will be turned into completion options automatically
+	nc.Flag("format", "Define the output format").
+		Default("raw").
+		EnumVar(&c.format, "raw", "json")
+
+	// You can combine HintOptions with HintAction too
+	nc.Flag("host-with-multi", "Define a hostname").
+		HintAction(listHosts).
+		HintOptions("myhost.com").
+		String()
+
+	// And combine with themselves
+	nc.Flag("host-with-multi-options", "Define a hostname").
+		HintOptions("myhost.com").
+		HintOptions("myhost2.com").
+		String()
+
+	// If you specify HintOptions/HintActions for Enum/EnumVar, the options
+	// provided for Enum/EnumVar will be overridden.
+	nc.Flag("format-with-override-1", "Define a format").
+		HintAction(listHosts).
+		Enum("option1", "option2")
+
+	nc.Flag("format-with-override-2", "Define a format").
+		HintOptions("myhost.com", "myhost2.com").
+		Enum("option1", "option2")
+}
+
+func addSubCommand(app *kingpin.Application, name string, description string) {
+	c := app.Command(name, description).Action(func(c *kingpin.ParseContext) error {
+		fmt.Printf("Would have run command %s.\n", name)
+		return nil
+	})
+	c.Flag("nop-flag", "Example of a flag with no options").Bool()
+}
+
+func main() {
+	app := kingpin.New("completion", "My application with bash completion.")
+	app.Flag("flag-1", "").String()
+	app.Flag("flag-2", "").HintOptions("opt1", "opt2").String()
+
+	configureNetcatCommand(app)
+
+	// Add some additional top level commands
+	addSubCommand(app, "ls", "Additional top level command to show command completion")
+	addSubCommand(app, "ping", "Additional top level command to show command completion")
+	addSubCommand(app, "nmap", "Additional top level command to show command completion")
+
+	kingpin.MustParse(app.Parse(os.Args[1:]))
+}

--- a/flags.go
+++ b/flags.go
@@ -159,6 +159,7 @@ func (f *flagGroup) visibleFlags() int {
 type FlagClause struct {
 	parserMixin
 	actionMixin
+	completionsMixin
 	name          string
 	shorthand     byte
 	help          string
@@ -236,6 +237,34 @@ func (f *FlagClause) Action(action Action) *FlagClause {
 func (f *FlagClause) PreAction(action Action) *FlagClause {
 	f.addPreAction(action)
 	return f
+}
+
+// HintAction registers a HintAction (function) for the flag to provide completions
+func (a *FlagClause) HintAction(action HintAction) *FlagClause {
+	a.addHintAction(action)
+	return a
+}
+
+// HintOptions registers any number of options for the flag to provide completions
+func (a *FlagClause) HintOptions(options ...string) *FlagClause {
+	a.addHintAction(func() []string {
+		return options
+	})
+	return a
+}
+
+func (a *FlagClause) EnumVar(target *string, options ...string) {
+	a.parserMixin.EnumVar(target, options...)
+	a.addHintActionBuiltin(func() []string {
+		return options
+	})
+}
+
+func (a *FlagClause) Enum(options ...string) (target *string) {
+	a.addHintActionBuiltin(func() []string {
+		return options
+	})
+	return a.parserMixin.Enum(options...)
 }
 
 // Default values for this flag. They *must* be parseable by the value of the flag.

--- a/parser.go
+++ b/parser.go
@@ -92,6 +92,7 @@ type ParseContext struct {
 	peek            []*Token
 	argi            int // Index of current command-line arg we're processing.
 	args            []string
+	rawArgs         []string
 	flags           *flagGroup
 	arguments       *argGroup
 	argumenti       int // Cursor into arguments
@@ -125,6 +126,7 @@ func tokenize(args []string, ignoreDefault bool) *ParseContext {
 	return &ParseContext{
 		ignoreDefault: ignoreDefault,
 		args:          args,
+		rawArgs:       args,
 		flags:         newFlagGroup(),
 		arguments:     newArgGroup(),
 	}

--- a/templates.go
+++ b/templates.go
@@ -231,3 +231,32 @@ Commands:
 {{template "FormatCommands" .App}}
 {{end}}\
 `
+
+var BashCompletionTemplate = `
+_{{.App.Name}}_bash_autocomplete() {
+    local cur prev opts base
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    opts=$( ${COMP_WORDS[0]} --completion-bash ${COMP_WORDS[@]:1:$COMP_CWORD} )
+    COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+    return 0
+}
+complete -F _{{.App.Name}}_bash_autocomplete {{.App.Name}}
+
+`
+
+var ZshCompletionTemplate = `
+#compdef {{.App.Name}}
+autoload -U compinit && compinit
+autoload -U bashcompinit && bashcompinit
+
+_{{.App.Name}}_bash_autocomplete() {
+    local cur prev opts base
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    opts=$( ${COMP_WORDS[0]} --completion-bash ${COMP_WORDS[@]:1:$COMP_CWORD} )
+    COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+    return 0
+}
+complete -F _{{.App.Name}}_bash_autocomplete {{.App.Name}}
+`


### PR DESCRIPTION
I've implemented deep bash completion integration within the library. Work towards #75.  A bash completion script can call into any tool using Kingpin by using a new flag `--help-bash-completion` as the first argument, followed by subsequent user-entered arguments. 

Opening this PR to get some eyes on it, and see how it can be improved. Happy to add docs once we're happy with the overall structure of it (Since this does bring some new API):

- `type HintAction func(args []string) []string` A new type `HintAction`, a function that returns a list of options for completions.
- `func (a *ArgClause) HintAction(action HintAction) *ArgClause` to register a `HintAction` to call when completions are requested for an argument.
- `func (a *ArgClause) HintOptions(options ...string) *ArgClause` to register a static slice of strings to provide as completions when requested. Internally registers a `HintAction` that returns this slice.
- `func (a *FlagClause) HintAction(action HintAction) *FlagClause` - Same as described for `ArgClause`
- `func (a *FlagClause) HintOptions(options ...string) *FlagClause`  - Same as described for `ArgClause`

Additionally, FlagClause `EnumVar` will register all available `EnumVar` options as completion options too. 

Users will be presented with completion options for:
- sub-commands
- flags for a command (when `-` was the last user-entered argument)
- options for a flag (when the second last argument was a flag)

There's a bit of re-shuffling in this PR, including a new mixin (`cmdMixin`), due to some shared logic between the `Application` type and the `CmdClause` type for autocompletion

Additionally, a lot of logic from `Application.execute` has been moved to `Application.Parse` to allow different code paths for bash completion / normal execution.

An additional argument has been added to `Application.applyPreActions` to change whether or not sub commands should have preActions dispatched, since this causes issues with functionality such as `help`, and `--version`

Included are two scripts `support/bash_completion` and `support/zsh_completion` which should be modified and then sourced/installed by end users within their shells to enable bash completion. 
