### PR TITLE
Fix readme instructions for generating man page

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ contextual help if `--help` is encountered at any point in the command line
 - POSIX-style short flag combining (`-a -b` -> `-ab`).
 - Short-flag+parameter combining (`-a parm` -> `-aparm`).
 - Read command-line from files (`@<file>`).
-- Automatically generate man pages (`--man-page`).
+- Automatically generate man pages (`--help-man`).
 
 ## User-visible changes between v1 and v2
 


### PR DESCRIPTION
The flag to generate man pages was changed in c553ee39c6b336f00108d7e13b736cf1dd97a2f2 from `--man-page` to `--help-man`. This just updates the Readme to reflect that.