### PR TITLE
Fix an example import to canonical package path

### DIFF
--- a/examples/completion/main.go
+++ b/examples/completion/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/alecthomas/kingpin"
+	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 func listHosts() []string {


### PR DESCRIPTION
This fixes an issue that causes both 'github.com/alecthomas/kingpin' and
'gopkg.in/alecthomas/kingpin.v2' to be dependencies when using kingpin.