### PR TITLE
Autocomplete a command's args

### DIFF
--- a/app.go
+++ b/app.go
@@ -670,10 +670,10 @@ func (a *Application) completionOptions(context *ParseContext) []string {
 			}
 		}
 		return options
-	} else {
-		// Perform completion for sub commands.
-		return target.CmdCompletion()
 	}
+
+	// Perform completion for sub commands and arguments.
+	return target.CmdCompletion()
 }
 
 func (a *Application) generateBashCompletion(context *ParseContext) {

--- a/app.go
+++ b/app.go
@@ -650,7 +650,7 @@ func (a *Application) completionOptions(context *ParseContext) []string {
 		options, flagMatched, valueMatched := target.FlagCompletion(flagName, flagValue)
 		if valueMatched {
 			// Value Matched. Show cmdCompletions
-			return target.CmdCompletion()
+			return target.CmdCompletion(context)
 		}
 
 		// Add top level flags if we're not at the top level and no match was found.
@@ -658,7 +658,7 @@ func (a *Application) completionOptions(context *ParseContext) []string {
 			topOptions, topFlagMatched, topValueMatched := a.FlagCompletion(flagName, flagValue)
 			if topValueMatched {
 				// Value Matched. Back to cmdCompletions
-				return target.CmdCompletion()
+				return target.CmdCompletion(context)
 			}
 
 			if topFlagMatched {
@@ -673,7 +673,7 @@ func (a *Application) completionOptions(context *ParseContext) []string {
 	}
 
 	// Perform completion for sub commands and arguments.
-	return target.CmdCompletion()
+	return target.CmdCompletion(context)
 }
 
 func (a *Application) generateBashCompletion(context *ParseContext) {

--- a/app_test.go
+++ b/app_test.go
@@ -248,8 +248,9 @@ func TestBashCompletionOptions(t *testing.T) {
 	three.Flag("flag-4", "").String()
 	three.Arg("arg-1", "").String()
 	three.Arg("arg-2", "").HintOptions("arg-2-opt-1", "arg-2-opt-2").String()
-	three.Arg("arg-3", "").HintAction(func() []string {
-		return []string{"arg-3-opt-1", "arg-3-opt-2"}
+	three.Arg("arg-3", "").String()
+	three.Arg("arg-4", "").HintAction(func() []string {
+		return []string{"arg-4-opt-1", "arg-4-opt-2"}
 	}).String()
 
 	cases := []struct {
@@ -345,24 +346,45 @@ func TestBashCompletionOptions(t *testing.T) {
 
 		// Args complete
 		{
-			// After a command with arg options
+			// After a command with an arg with no options, nothing should be
+			// shown
 			Args:            "--completion-bash three ",
-			ExpectedOptions: []string{"arg-2-opt-1", "arg-2-opt-2", "arg-3-opt-1", "arg-3-opt-2"},
+			ExpectedOptions: []string(nil),
 		},
 		{
-			// But not after flag start
+			// After a command with an arg, explicitly starting a flag should
+			// complete flags
 			Args:            "--completion-bash three --",
 			ExpectedOptions: []string{"--flag-0", "--flag-1", "--flag-4", "--help"},
 		},
 		{
-			// Completes args after one already listed
-			Args:            "--completion-bash three firstArg ",
-			ExpectedOptions: []string{"arg-2-opt-1", "arg-2-opt-2", "arg-3-opt-1", "arg-3-opt-2"},
+			// After a command with an arg that does have completions, they
+			// should be shown
+			Args:            "--completion-bash three arg1 ",
+			ExpectedOptions: []string{"arg-2-opt-1", "arg-2-opt-2"},
 		},
 		{
-			// Completes args after a flag
-			Args:            "--completion-bash three firstArg --flag-4 ",
-			ExpectedOptions: []string{"arg-2-opt-1", "arg-2-opt-2", "arg-3-opt-1", "arg-3-opt-2"},
+			// After a command with an arg that does have completions, but a
+			// flag is started, flag options should be completed
+			Args:            "--completion-bash three arg1 --",
+			ExpectedOptions: []string{"--flag-0", "--flag-1", "--flag-4", "--help"},
+		},
+		{
+			// After a command with an arg that has no completions, and isn't first,
+			// nothing should be shown
+			Args:            "--completion-bash three arg1 arg2 ",
+			ExpectedOptions: []string(nil),
+		},
+		{
+			// After a command with a different arg that also has completions,
+			// those different options should be shown
+			Args:            "--completion-bash three arg1 arg2 arg3 ",
+			ExpectedOptions: []string{"arg-4-opt-1", "arg-4-opt-2"},
+		},
+		{
+			// After a command with all args listed, nothing should complete
+			Args:            "--completion-bash three arg1 arg2 arg3 arg4",
+			ExpectedOptions: []string(nil),
 		},
 	}
 

--- a/app_test.go
+++ b/app_test.go
@@ -244,13 +244,21 @@ func TestBashCompletionOptions(t *testing.T) {
 	two.Flag("flag-2", "").String()
 	two.Flag("flag-3", "").HintOptions("opt4", "opt5", "opt6").String()
 
+	three := a.Command("three", "")
+	three.Flag("flag-4", "").String()
+	three.Arg("arg-1", "").String()
+	three.Arg("arg-2", "").HintOptions("arg-2-opt-1", "arg-2-opt-2").String()
+	three.Arg("arg-3", "").HintAction(func() []string {
+		return []string{"arg-3-opt-1", "arg-3-opt-2"}
+	}).String()
+
 	cases := []struct {
 		Args            string
 		ExpectedOptions []string
 	}{
 		{
 			Args:            "--completion-bash",
-			ExpectedOptions: []string{"help", "one", "two"},
+			ExpectedOptions: []string{"help", "one", "three", "two"},
 		},
 		{
 			Args:            "--completion-bash --",
@@ -263,7 +271,7 @@ func TestBashCompletionOptions(t *testing.T) {
 		{
 			// No options available for flag-0, return to cmd completion
 			Args:            "--completion-bash --flag-0",
-			ExpectedOptions: []string{"help", "one", "two"},
+			ExpectedOptions: []string{"help", "one", "three", "two"},
 		},
 		{
 			Args:            "--completion-bash --flag-0 --",
@@ -279,7 +287,7 @@ func TestBashCompletionOptions(t *testing.T) {
 		},
 		{
 			Args:            "--completion-bash --flag-1 opt1",
-			ExpectedOptions: []string{"help", "one", "two"},
+			ExpectedOptions: []string{"help", "one", "three", "two"},
 		},
 		{
 			Args:            "--completion-bash --flag-1 opt1 --",
@@ -333,6 +341,28 @@ func TestBashCompletionOptions(t *testing.T) {
 		{
 			Args:            "--completion-bash two --flag-3 opt4 --",
 			ExpectedOptions: []string{"--help", "--flag-2", "--flag-3", "--flag-0", "--flag-1"},
+		},
+
+		// Args complete
+		{
+			// After a command with arg options
+			Args:            "--completion-bash three ",
+			ExpectedOptions: []string{"arg-2-opt-1", "arg-2-opt-2", "arg-3-opt-1", "arg-3-opt-2"},
+		},
+		{
+			// But not after flag start
+			Args:            "--completion-bash three --",
+			ExpectedOptions: []string{"--flag-0", "--flag-1", "--flag-4", "--help"},
+		},
+		{
+			// Completes args after one already listed
+			Args:            "--completion-bash three firstArg ",
+			ExpectedOptions: []string{"arg-2-opt-1", "arg-2-opt-2", "arg-3-opt-1", "arg-3-opt-2"},
+		},
+		{
+			// Completes args after a flag
+			Args:            "--completion-bash three firstArg --flag-4 ",
+			ExpectedOptions: []string{"arg-2-opt-1", "arg-2-opt-2", "arg-3-opt-1", "arg-3-opt-2"},
 		},
 	}
 

--- a/args.go
+++ b/args.go
@@ -64,6 +64,7 @@ func (a *argGroup) init() error {
 type ArgClause struct {
 	actionMixin
 	parserMixin
+	completionsMixin
 	name          string
 	help          string
 	defaultValues []string
@@ -104,6 +105,20 @@ func (a *ArgClause) Action(action Action) *ArgClause {
 
 func (a *ArgClause) PreAction(action Action) *ArgClause {
 	a.addPreAction(action)
+	return a
+}
+
+// HintAction registers a HintAction (function) for the arg to provide completions
+func (a *ArgClause) HintAction(action HintAction) *ArgClause {
+	a.addHintAction(action)
+	return a
+}
+
+// HintOptions registers any number of options for the flag to provide completions
+func (a *ArgClause) HintOptions(options ...string) *ArgClause {
+	a.addHintAction(func() []string {
+		return options
+	})
 	return a
 }
 

--- a/cmd.go
+++ b/cmd.go
@@ -13,17 +13,18 @@ type cmdMixin struct {
 }
 
 func (c *cmdMixin) CmdCompletion() []string {
-	rv := []string{}
-	if len(c.cmdGroup.commandOrder) > 0 {
-		// This command has subcommands. We should
-		// show these to the user.
-		for _, option := range c.cmdGroup.commandOrder {
-			rv = append(rv, option.name)
-		}
-	} else {
-		// No subcommands
-		rv = nil
+	var rv []string
+
+	// If this command has subcommands, we should show these to the user.
+	for _, option := range c.cmdGroup.commandOrder {
+		rv = append(rv, option.name)
 	}
+
+	// Add any completions from args as well
+	for _, arg := range c.argGroup.args {
+		rv = append(rv, arg.resolveCompletions()...)
+	}
+
 	return rv
 }
 

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -1,6 +1,7 @@
 package kingpin
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/alecthomas/assert"
@@ -19,6 +20,19 @@ func parseAndExecute(app *Application, context *ParseContext) (string, error) {
 	}
 
 	return app.execute(context, selected)
+}
+
+func complete(t *testing.T, app *Application, args ...string) []string {
+	context, err := app.ParseContext(args)
+	assert.NoError(t, err)
+	if err != nil {
+		return nil
+	}
+
+	completions := app.completionOptions(context)
+	sort.Strings(completions)
+
+	return completions
 }
 
 func TestNestedCommands(t *testing.T) {
@@ -271,8 +285,63 @@ func TestCmdCompletion(t *testing.T) {
 	two.Command("sub1", "")
 	two.Command("sub2", "")
 
-	context, _ := app.ParseContext([]string{})
+	assert.Equal(t, []string{"help", "one", "two"}, complete(t, app))
+	assert.Equal(t, []string{"sub1", "sub2"}, complete(t, app, "two"))
+}
 
-	assert.Equal(t, []string{"help", "one", "two"}, app.CmdCompletion(context))
-	assert.Equal(t, []string{"sub1", "sub2"}, two.CmdCompletion(context))
+func TestDefaultCmdCompletion(t *testing.T) {
+	app := newTestApp()
+
+	cmd1 := app.Command("cmd1", "")
+
+	cmd1Sub1 := cmd1.Command("cmd1-sub1", "")
+	cmd1Sub1.Arg("cmd1-sub1-arg1", "").HintOptions("cmd1-arg1").String()
+
+	cmd2 := app.Command("cmd2", "").Default()
+
+	cmd2.Command("cmd2-sub1", "")
+
+	cmd2Sub2 := cmd2.Command("cmd2-sub2", "").Default()
+
+	cmd2Sub2Sub1 := cmd2Sub2.Command("cmd2-sub2-sub1", "").Default()
+	cmd2Sub2Sub1.Arg("cmd2-sub2-sub1-arg1", "").HintOptions("cmd2-sub2-sub1-arg1").String()
+	cmd2Sub2Sub1.Arg("cmd2-sub2-sub1-arg2", "").HintOptions("cmd2-sub2-sub1-arg2").String()
+
+	// Without args, should get:
+	//   - root cmds (incuding implicit "help")
+	//   - thread of default cmds
+	//   - first arg hints for the final default cmd
+	assert.Equal(t, []string{"cmd1", "cmd2", "cmd2-sub1", "cmd2-sub2", "cmd2-sub2-sub1", "cmd2-sub2-sub1-arg1", "help"}, complete(t, app))
+
+	// With a non-default cmd already listed, should get:
+	//   - sub cmds of that arg
+	assert.Equal(t, []string{"cmd1-sub1"}, complete(t, app, "cmd1"))
+
+	// With an explicit default cmd listed, should get:
+	//   - default child-cmds
+	//   - first arg hints for the final default cmd
+	assert.Equal(t, []string{"cmd2-sub1", "cmd2-sub2", "cmd2-sub2-sub1", "cmd2-sub2-sub1-arg1"}, complete(t, app, "cmd2"))
+
+	// Args should be completed when all preceding cmds are explicit, and when
+	// any of them are implicit (not listed). Check this by trying all possible
+	// combinations of choosing/excluding the three levels of cmds. This tests
+	// root-level default, middle default, and end default.
+	for i := 0; i < 8; i++ {
+		var cmdline []string
+
+		if i&1 != 0 {
+			cmdline = append(cmdline, "cmd2")
+		}
+		if i&2 != 0 {
+			cmdline = append(cmdline, "cmd2-sub2")
+		}
+		if i&4 != 0 {
+			cmdline = append(cmdline, "cmd2-sub2-sub1")
+		}
+
+		assert.Contains(t, complete(t, app, cmdline...), "cmd2-sub2-sub1-arg1", "with cmdline: %v", cmdline)
+	}
+
+	// With both args of a default sub cmd, should get no completions
+	assert.Empty(t, complete(t, app, "arg1", "arg2"))
 }

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -271,6 +271,8 @@ func TestCmdCompletion(t *testing.T) {
 	two.Command("sub1", "")
 	two.Command("sub2", "")
 
-	assert.Equal(t, []string{"one", "two"}, app.CmdCompletion())
-	assert.Equal(t, []string{"sub1", "sub2"}, two.CmdCompletion())
+	context, _ := app.ParseContext([]string{})
+
+	assert.Equal(t, []string{"help", "one", "two"}, app.CmdCompletion(context))
+	assert.Equal(t, []string{"sub1", "sub2"}, two.CmdCompletion(context))
 }

--- a/parser.go
+++ b/parser.go
@@ -297,6 +297,7 @@ loop:
 			if flag, err := context.flags.parse(context); err != nil {
 				if !ignoreDefault {
 					if cmd := cmds.defaultSubcommand(); cmd != nil {
+						cmd.completionAlts = cmds.cmdNames()
 						context.matchedCmd(cmd)
 						cmds = cmd.cmdGroup
 						break
@@ -314,6 +315,7 @@ loop:
 				if !ok {
 					if !ignoreDefault {
 						if cmd = cmds.defaultSubcommand(); cmd != nil {
+							cmd.completionAlts = cmds.cmdNames()
 							selectedDefault = true
 						}
 					}
@@ -324,6 +326,7 @@ loop:
 				if cmd == HelpCommand {
 					ignoreDefault = true
 				}
+				cmd.completionAlts = nil
 				context.matchedCmd(cmd)
 				cmds = cmd.cmdGroup
 				if !selectedDefault {
@@ -352,6 +355,7 @@ loop:
 	// Move to innermost default command.
 	for !ignoreDefault {
 		if cmd := cmds.defaultSubcommand(); cmd != nil {
+			cmd.completionAlts = cmds.cmdNames()
 			context.matchedCmd(cmd)
 			cmds = cmd.cmdGroup
 		} else {


### PR DESCRIPTION
This change handles autocompleting scenarios like `program command <tab>` where `command` has arguments with completion options or an action-fn. For ex, if git used kingpin, `git checkout <tab>` could complete branch names.