### PR TITLE
Switch to text/template from Go 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 sudo: false
 language: go
 install: go get -t -v ./...
-go: 1.2
+go: 1.6

--- a/README.md
+++ b/README.md
@@ -609,7 +609,7 @@ You can see an in depth example of the completion API within
 
 ### Custom help
 
-Kingpin v2 supports templatised help using the text/template library (actually, [a fork](https://github.com/alecthomas/template)).
+Kingpin v2 supports templatised help using the text/template library.
 
 You can specify the template to use with the [Application.UsageTemplate()](http://godoc.org/gopkg.in/alecthomas/kingpin.v2#Application.UsageTemplate) function.
 

--- a/cmd/genvalues/main.go
+++ b/cmd/genvalues/main.go
@@ -5,8 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-
-	"github.com/alecthomas/template"
+	"text/template"
 )
 
 const (
@@ -37,9 +36,9 @@ func (f *{{.|ValueName}}) String() string { return {{.|Format}} }
 
 {{if .Help}}
 // {{.Help}}
-{{else}}\
+{{else -}}
 // {{.|Name}} parses the next command-line value as {{.Type}}.
-{{end}}\
+{{end -}}
 func (p *parserMixin) {{.|Name}}() (target *{{.Type}}) {
 	target = new({{.Type}})
 	p.{{.|Name}}Var(target)

--- a/templates.go
+++ b/templates.go
@@ -1,181 +1,181 @@
 package kingpin
 
 // Default usage template.
-var DefaultUsageTemplate = `{{define "FormatCommand"}}\
-{{if .FlagSummary}} {{.FlagSummary}}{{end}}\
-{{range .Args}} {{if not .Required}}[{{end}}<{{.Name}}>{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}\
-{{end}}\
+var DefaultUsageTemplate = `{{define "FormatCommand" -}}
+{{if .FlagSummary}} {{.FlagSummary}}{{end -}}
+{{range .Args}} {{if not .Required}}[{{end}}<{{.Name}}>{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end -}}
+{{end -}}
 
-{{define "FormatCommands"}}\
-{{range .FlattenedCommands}}\
-{{if not .Hidden}}\
+{{define "FormatCommands" -}}
+{{range .FlattenedCommands -}}
+{{if not .Hidden -}}
   {{.FullCommand}}{{if .Default}}*{{end}}{{template "FormatCommand" .}}
 {{.Help|Wrap 4}}
-{{end}}\
-{{end}}\
-{{end}}\
+{{end -}}
+{{end -}}
+{{end -}}
 
-{{define "FormatUsage"}}\
+{{define "FormatUsage" -}}
 {{template "FormatCommand" .}}{{if .Commands}} <command> [<args> ...]{{end}}
 {{if .Help}}
-{{.Help|Wrap 0}}\
-{{end}}\
+{{.Help|Wrap 0 -}}
+{{end -}}
 
-{{end}}\
+{{end -}}
 
-{{if .Context.SelectedCommand}}\
+{{if .Context.SelectedCommand -}}
 usage: {{.App.Name}} {{.Context.SelectedCommand}}{{template "FormatUsage" .Context.SelectedCommand}}
-{{else}}\
+{{else -}}
 usage: {{.App.Name}}{{template "FormatUsage" .App}}
-{{end}}\
-{{if .Context.Flags}}\
+{{end -}}
+{{if .Context.Flags -}}
 Flags:
 {{.Context.Flags|FlagsToTwoColumns|FormatTwoColumns}}
-{{end}}\
-{{if .Context.Args}}\
+{{end -}}
+{{if .Context.Args -}}
 Args:
 {{.Context.Args|ArgsToTwoColumns|FormatTwoColumns}}
-{{end}}\
-{{if .Context.SelectedCommand}}\
-{{if len .Context.SelectedCommand.Commands}}\
+{{end -}}
+{{if .Context.SelectedCommand -}}
+{{if len .Context.SelectedCommand.Commands -}}
 Subcommands:
 {{template "FormatCommands" .Context.SelectedCommand}}
-{{end}}\
-{{else if .App.Commands}}\
+{{end -}}
+{{else if .App.Commands -}}
 Commands:
 {{template "FormatCommands" .App}}
-{{end}}\
+{{end -}}
 `
 
 // Usage template where command's optional flags are listed separately
-var SeparateOptionalFlagsUsageTemplate = `{{define "FormatCommand"}}\
-{{if .FlagSummary}} {{.FlagSummary}}{{end}}\
-{{range .Args}} {{if not .Required}}[{{end}}<{{.Name}}>{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}\
-{{end}}\
+var SeparateOptionalFlagsUsageTemplate = `{{define "FormatCommand" -}}
+{{if .FlagSummary}} {{.FlagSummary}}{{end -}}
+{{range .Args}} {{if not .Required}}[{{end}}<{{.Name}}>{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end -}}
+{{end -}}
 
-{{define "FormatCommands"}}\
-{{range .FlattenedCommands}}\
-{{if not .Hidden}}\
+{{define "FormatCommands" -}}
+{{range .FlattenedCommands -}}
+{{if not .Hidden -}}
   {{.FullCommand}}{{if .Default}}*{{end}}{{template "FormatCommand" .}}
 {{.Help|Wrap 4}}
-{{end}}\
-{{end}}\
-{{end}}\
+{{end -}}
+{{end -}}
+{{end -}}
 
-{{define "FormatUsage"}}\
+{{define "FormatUsage" -}}
 {{template "FormatCommand" .}}{{if .Commands}} <command> [<args> ...]{{end}}
 {{if .Help}}
-{{.Help|Wrap 0}}\
-{{end}}\
+{{.Help|Wrap 0 -}}
+{{end -}}
 
-{{end}}\
-{{if .Context.SelectedCommand}}\
+{{end -}}
+{{if .Context.SelectedCommand -}}
 usage: {{.App.Name}} {{.Context.SelectedCommand}}{{template "FormatUsage" .Context.SelectedCommand}}
-{{else}}\
+{{else -}}
 usage: {{.App.Name}}{{template "FormatUsage" .App}}
-{{end}}\
+{{end -}}
 
-{{if .Context.Flags|RequiredFlags}}\
+{{if .Context.Flags|RequiredFlags -}}
 Required flags:
 {{.Context.Flags|RequiredFlags|FlagsToTwoColumns|FormatTwoColumns}}
-{{end}}\
-{{if  .Context.Flags|OptionalFlags}}\
+{{end -}}
+{{if  .Context.Flags|OptionalFlags -}}
 Optional flags:
 {{.Context.Flags|OptionalFlags|FlagsToTwoColumns|FormatTwoColumns}}
-{{end}}\
-{{if .Context.Args}}\
+{{end -}}
+{{if .Context.Args -}}
 Args:
 {{.Context.Args|ArgsToTwoColumns|FormatTwoColumns}}
-{{end}}\
-{{if .Context.SelectedCommand}}\
+{{end -}}
+{{if .Context.SelectedCommand -}}
 Subcommands:
-{{if .Context.SelectedCommand.Commands}}\
+{{if .Context.SelectedCommand.Commands -}}
 {{template "FormatCommands" .Context.SelectedCommand}}
-{{end}}\
-{{else if .App.Commands}}\
+{{end -}}
+{{else if .App.Commands -}}
 Commands:
 {{template "FormatCommands" .App}}
-{{end}}\
+{{end -}}
 `
 
 // Usage template with compactly formatted commands.
-var CompactUsageTemplate = `{{define "FormatCommand"}}\
-{{if .FlagSummary}} {{.FlagSummary}}{{end}}\
-{{range .Args}} {{if not .Required}}[{{end}}<{{.Name}}>{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}\
-{{end}}\
+var CompactUsageTemplate = `{{define "FormatCommand" -}}
+{{if .FlagSummary}} {{.FlagSummary}}{{end -}}
+{{range .Args}} {{if not .Required}}[{{end}}<{{.Name}}>{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end -}}
+{{end -}}
 
-{{define "FormatCommandList"}}\
-{{range .}}\
-{{if not .Hidden}}\
+{{define "FormatCommandList" -}}
+{{range . -}}
+{{if not .Hidden -}}
 {{.Depth|Indent}}{{.Name}}{{if .Default}}*{{end}}{{template "FormatCommand" .}}
-{{end}}\
-{{template "FormatCommandList" .Commands}}\
-{{end}}\
-{{end}}\
+{{end -}}
+{{template "FormatCommandList" .Commands -}}
+{{end -}}
+{{end -}}
 
-{{define "FormatUsage"}}\
+{{define "FormatUsage" -}}
 {{template "FormatCommand" .}}{{if .Commands}} <command> [<args> ...]{{end}}
 {{if .Help}}
-{{.Help|Wrap 0}}\
-{{end}}\
+{{.Help|Wrap 0 -}}
+{{end -}}
 
-{{end}}\
+{{end -}}
 
-{{if .Context.SelectedCommand}}\
+{{if .Context.SelectedCommand -}}
 usage: {{.App.Name}} {{.Context.SelectedCommand}}{{template "FormatUsage" .Context.SelectedCommand}}
-{{else}}\
+{{else -}}
 usage: {{.App.Name}}{{template "FormatUsage" .App}}
-{{end}}\
-{{if .Context.Flags}}\
+{{end -}}
+{{if .Context.Flags -}}
 Flags:
 {{.Context.Flags|FlagsToTwoColumns|FormatTwoColumns}}
-{{end}}\
-{{if .Context.Args}}\
+{{end -}}
+{{if .Context.Args -}}
 Args:
 {{.Context.Args|ArgsToTwoColumns|FormatTwoColumns}}
-{{end}}\
-{{if .Context.SelectedCommand}}\
-{{if .Context.SelectedCommand.Commands}}\
+{{end -}}
+{{if .Context.SelectedCommand -}}
+{{if .Context.SelectedCommand.Commands -}}
 Commands:
   {{.Context.SelectedCommand}}
 {{template "FormatCommandList" .Context.SelectedCommand.Commands}}
-{{end}}\
-{{else if .App.Commands}}\
+{{end -}}
+{{else if .App.Commands -}}
 Commands:
 {{template "FormatCommandList" .App.Commands}}
-{{end}}\
+{{end -}}
 `
 
-var ManPageTemplate = `{{define "FormatFlags"}}\
-{{range .Flags}}\
-{{if not .Hidden}}\
+var ManPageTemplate = `{{define "FormatFlags" -}}
+{{range .Flags -}}
+{{if not .Hidden -}}
 .TP
-\fB{{if .Short}}-{{.Short|Char}}, {{end}}--{{.Name}}{{if not .IsBoolFlag}}={{.FormatPlaceHolder}}{{end}}\\fR
+\fB{{if .Short}}-{{.Short|Char}}, {{end}}--{{.Name}}{{if not .IsBoolFlag}}={{.FormatPlaceHolder}}{{end}}\fR
 {{.Help}}
-{{end}}\
-{{end}}\
-{{end}}\
+{{end -}}
+{{end -}}
+{{end -}}
 
-{{define "FormatCommand"}}\
-{{if .FlagSummary}} {{.FlagSummary}}{{end}}\
-{{range .Args}} {{if not .Required}}[{{end}}<{{.Name}}{{if .Default}}*{{end}}>{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}\
-{{end}}\
+{{define "FormatCommand" -}}
+{{if .FlagSummary}} {{.FlagSummary}}{{end -}}
+{{range .Args}} {{if not .Required}}[{{end}}<{{.Name}}{{if .Default}}*{{end}}>{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end -}}
+{{end -}}
 
-{{define "FormatCommands"}}\
-{{range .FlattenedCommands}}\
-{{if not .Hidden}}\
+{{define "FormatCommands" -}}
+{{range .FlattenedCommands -}}
+{{if not .Hidden -}}
 .SS
-\fB{{.FullCommand}}{{template "FormatCommand" .}}\\fR
+\fB{{.FullCommand}}{{template "FormatCommand" .}}\fR
 .PP
 {{.Help}}
-{{template "FormatFlags" .}}\
-{{end}}\
-{{end}}\
-{{end}}\
+{{template "FormatFlags" . -}}
+{{end -}}
+{{end -}}
+{{end -}}
 
-{{define "FormatUsage"}}\
-{{template "FormatCommand" .}}{{if .Commands}} <command> [<args> ...]{{end}}\\fR
-{{end}}\
+{{define "FormatUsage" -}}
+{{template "FormatCommand" .}}{{if .Commands}} <command> [<args> ...]{{end}}\fR
+{{end -}}
 
 .TH {{.App.Name}} 1 {{.App.Version}} "{{.App.Author}}"
 .SH "NAME"
@@ -186,50 +186,50 @@ var ManPageTemplate = `{{define "FormatFlags"}}\
 .SH "DESCRIPTION"
 {{.App.Help}}
 .SH "OPTIONS"
-{{template "FormatFlags" .App}}\
-{{if .App.Commands}}\
+{{template "FormatFlags" .App -}}
+{{if .App.Commands -}}
 .SH "COMMANDS"
-{{template "FormatCommands" .App}}\
-{{end}}\
+{{template "FormatCommands" .App -}}
+{{end -}}
 `
 
 // Default usage template.
-var LongHelpTemplate = `{{define "FormatCommand"}}\
-{{if .FlagSummary}} {{.FlagSummary}}{{end}}\
-{{range .Args}} {{if not .Required}}[{{end}}<{{.Name}}>{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}\
-{{end}}\
+var LongHelpTemplate = `{{define "FormatCommand" -}}
+{{if .FlagSummary}} {{.FlagSummary}}{{end -}}
+{{range .Args}} {{if not .Required}}[{{end}}<{{.Name}}>{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end -}}
+{{end -}}
 
-{{define "FormatCommands"}}\
-{{range .FlattenedCommands}}\
-{{if not .Hidden}}\
+{{define "FormatCommands" -}}
+{{range .FlattenedCommands -}}
+{{if not .Hidden -}}
   {{.FullCommand}}{{template "FormatCommand" .}}
 {{.Help|Wrap 4}}
 {{with .Flags|FlagsToTwoColumns}}{{FormatTwoColumnsWithIndent . 4 2}}{{end}}
-{{end}}\
-{{end}}\
-{{end}}\
+{{end -}}
+{{end -}}
+{{end -}}
 
-{{define "FormatUsage"}}\
+{{define "FormatUsage" -}}
 {{template "FormatCommand" .}}{{if .Commands}} <command> [<args> ...]{{end}}
 {{if .Help}}
-{{.Help|Wrap 0}}\
-{{end}}\
+{{.Help|Wrap 0 -}}
+{{end -}}
 
-{{end}}\
+{{end -}}
 
 usage: {{.App.Name}}{{template "FormatUsage" .App}}
-{{if .Context.Flags}}\
+{{if .Context.Flags -}}
 Flags:
 {{.Context.Flags|FlagsToTwoColumns|FormatTwoColumns}}
-{{end}}\
-{{if .Context.Args}}\
+{{end -}}
+{{if .Context.Args -}}
 Args:
 {{.Context.Args|ArgsToTwoColumns|FormatTwoColumns}}
-{{end}}\
-{{if .App.Commands}}\
+{{end -}}
+{{if .App.Commands -}}
 Commands:
 {{template "FormatCommands" .App}}
-{{end}}\
+{{end -}}
 `
 
 var BashCompletionTemplate = `

--- a/usage.go
+++ b/usage.go
@@ -6,8 +6,7 @@ import (
 	"go/doc"
 	"io"
 	"strings"
-
-	"github.com/alecthomas/template"
+	"text/template"
 )
 
 var (


### PR DESCRIPTION
The text/template package now supports whitespace trimming.

https://golang.org/doc/go1.6#template