### PR TITLE
Parse bytes with github.com/dustin/go-humanize

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ $ go get gopkg.in/alecthomas/kingpin.v1
       Allows for values that look like flags to be processed.
     - Allow `--help` to be used with commands.
     - Support `Hidden()` flags.
-    - Parser for [units.Base2Bytes](https://github.com/alecthomas/units)
+    - Parser for [sizes in bytes with SI prefixes](https://godoc.org/github.com/dustin/go-humanize#ParseBytes)
       type. Allows for flags like `--ram=512MB` or `--ram=1GB`.
     - Add an `Enum()` value, allowing only one of a set of values
       to be selected. eg. `Flag(...).Enum("debug", "info", "warning")`.

--- a/parsers.go
+++ b/parsers.go
@@ -5,8 +5,6 @@ import (
 	"net/url"
 	"os"
 	"time"
-
-	"github.com/alecthomas/units"
 )
 
 type Settings interface {
@@ -36,10 +34,10 @@ func (p *parserMixin) Duration() (target *time.Duration) {
 	return
 }
 
-// Bytes parses numeric byte units. eg. 1.5KB
-func (p *parserMixin) Bytes() (target *units.Base2Bytes) {
-	target = new(units.Base2Bytes)
-	p.BytesVar(target)
+// Bytes parses numeric byte units with SI prefixes. eg. 1.5KB (1500B) or 1.5KiB (1536B)
+func (p *parserMixin) SIBytes() (target *uint64) {
+	target = new(uint64)
+	p.SIBytesVar(target)
 	return
 }
 
@@ -124,9 +122,9 @@ func (p *parserMixin) DurationVar(target *time.Duration) {
 	p.SetValue(newDurationValue(target))
 }
 
-// BytesVar parses numeric byte units. eg. 1.5KB
-func (p *parserMixin) BytesVar(target *units.Base2Bytes) {
-	p.SetValue(newBytesValue(target))
+// SIBytesVar parses numeric byte units. eg. 1.5KB
+func (p *parserMixin) SIBytesVar(target *uint64) {
+	p.SetValue(newSIBytesValue(target))
 }
 
 // IP sets the parser to a net.IP parser.

--- a/values.go
+++ b/values.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/alecthomas/units"
+	"github.com/dustin/go-humanize"
 )
 
 // NOTE: Most of the base type values were lifted from:
@@ -398,22 +398,21 @@ func (s *enumsValue) IsCumulative() bool {
 	return true
 }
 
-// -- units.Base2Bytes Value
-type bytesValue units.Base2Bytes
+type SIBytesValue uint64
 
-func newBytesValue(p *units.Base2Bytes) *bytesValue {
-	return (*bytesValue)(p)
+func newSIBytesValue(p *uint64) *SIBytesValue {
+	return (*SIBytesValue)(p)
 }
 
-func (d *bytesValue) Set(s string) error {
-	v, err := units.ParseBase2Bytes(s)
-	*d = bytesValue(v)
+func (d *SIBytesValue) Set(s string) error {
+	v, err := humanize.ParseBytes(s)
+	*d = SIBytesValue(v)
 	return err
 }
 
-func (d *bytesValue) Get() interface{} { return units.Base2Bytes(*d) }
+func (d *SIBytesValue) Get() interface{} { return uint64(*d) }
 
-func (d *bytesValue) String() string { return (*units.Base2Bytes)(d).String() }
+func (d *SIBytesValue) String() string { return humanize.Bytes(uint64(*d)) }
 
 func newExistingFileValue(target *string) *fileStatValue {
 	return newFileStatValue(target, func(s os.FileInfo) error {


### PR DESCRIPTION
This commit switches the string conversion of sizes in bytes to [github.com/dustin/go-humanize](https://github.com/dustin/go-humanize), which appears to be widely used in the Go community and well tested.