### PR TITLE
added SortCommands to enable sorting of sub commands

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -2,6 +2,7 @@ package kingpin
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -179,6 +180,25 @@ func (c *cmdGroup) init() error {
 
 func (c *cmdGroup) have() bool {
 	return len(c.commands) > 0
+}
+
+// SortCommand sort the command list lexicographically
+// (affect usage printing)
+// if recursive, it will apply the sort also on each sub-command
+func (c *cmdGroup) SortCommands(recursive bool) {
+	names := c.cmdNames()
+	sort.Strings(names)
+	for i, cmd := range names {
+		c.commandOrder[i] = c.commands[cmd]
+	}
+
+	if !recursive {
+		return
+	}
+
+	for _, cmd := range c.commandOrder {
+		cmd.SortCommands(true)
+	}
 }
 
 type CmdClauseValidator func(*CmdClause) error


### PR DESCRIPTION
Allow sorting the commands so that the usage will give the output in alphabetical order

1. Why do I need it? I have a modular application where sub commands are registered by the init function of various files, so for example on different OSes the list of commands may be different.

The result is that the order of command registration is not controlled and the usage message returns with a "strange" ordering.

2. Why not implement it in the usage template level? 
Because this will require implementing this for each usage template (to give one with alphabetical ordering and one without). I found little effect on sorting other than usage (mainly the choosing of the default sub command if more than one is specified), and I opted for simplicity.