### PR TITLE
Parse short argument as rune not as byte to support unicode characters

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -53,7 +53,7 @@ func (f *flagGroup) init(defaultEnvarPrefix string) error {
 }
 
 func (f *flagGroup) checkDuplicates() error {
-	seenShort := map[byte]bool{}
+	seenShort := map[rune]bool{}
 	seenLong := map[string]bool{}
 	for _, flag := range f.flagOrder {
 		if flag.shorthand != 0 {
@@ -147,7 +147,7 @@ type FlagClause struct {
 	completionsMixin
 	envarMixin
 	name          string
-	shorthand     byte
+	shorthand     rune
 	help          string
 	defaultValues []string
 	placeholder   string
@@ -295,7 +295,7 @@ func (f *FlagClause) Required() *FlagClause {
 }
 
 // Short sets the short flag name.
-func (f *FlagClause) Short(name byte) *FlagClause {
+func (f *FlagClause) Short(name rune) *FlagClause {
 	f.shorthand = name
 	return f
 }

--- a/flags_test.go
+++ b/flags_test.go
@@ -78,6 +78,14 @@ func TestShortFlag(t *testing.T) {
 	assert.True(t, *f)
 }
 
+func TestUnicodeShortFlag(t *testing.T) {
+	app := newTestApp()
+	f := app.Flag("aaa", "").Short('ä').Bool()
+	_, err := app.Parse([]string{"-ä"})
+	assert.NoError(t, err)
+	assert.True(t, *f)
+}
+
 func TestCombinedShortFlags(t *testing.T) {
 	app := newTestApp()
 	a := app.Flag("short0", "").Short('0').Bool()
@@ -90,12 +98,42 @@ func TestCombinedShortFlags(t *testing.T) {
 	assert.False(t, *c)
 }
 
+func TestCombinedUnicodeShortFlags(t *testing.T) {
+	app := newTestApp()
+	a := app.Flag("short0", "").Short('0').Bool()
+	b := app.Flag("short1", "").Short('1').Bool()
+	c := app.Flag("short2", "").Short('ä').Bool()
+	d := app.Flag("short3", "").Short('2').Bool()
+	_, err := app.Parse([]string{"-0ä1"})
+	assert.NoError(t, err)
+	assert.True(t, *a)
+	assert.True(t, *b)
+	assert.True(t, *c)
+	assert.False(t, *d)
+}
+
 func TestCombinedShortFlagArg(t *testing.T) {
 	a := newTestApp()
 	n := a.Flag("short", "").Short('s').Int()
 	_, err := a.Parse([]string{"-s10"})
 	assert.NoError(t, err)
 	assert.Equal(t, 10, *n)
+}
+
+func TestCombinedUnicodeShortFlagArg(t *testing.T) {
+	app := newTestApp()
+	a := app.Flag("short", "").Short('ä').Int()
+	_, err := app.Parse([]string{"-ä10"})
+	assert.NoError(t, err)
+	assert.Equal(t, 10, *a)
+}
+
+func TestCombinedUnicodeShortFlagUnicodeArg(t *testing.T) {
+	app := newTestApp()
+	a := app.Flag("short", "").Short('ä').String()
+	_, err := app.Parse([]string{"-äöö"})
+	assert.NoError(t, err)
+	assert.Equal(t, "öö", *a)
 }
 
 func TestEmptyShortFlagIsAnError(t *testing.T) {
@@ -267,11 +305,11 @@ func TestMultiHintActions(t *testing.T) {
 
 	a := c.Flag("foo", "foo").
 		HintAction(func() []string {
-		return []string{"opt1"}
-	}).
+			return []string{"opt1"}
+		}).
 		HintAction(func() []string {
-		return []string{"opt2"}
-	})
+			return []string{"opt2"}
+		})
 	args := a.resolveCompletions()
 	assert.Equal(t, []string{"opt1", "opt2"}, args)
 }
@@ -292,14 +330,14 @@ func TestCombinationEnumActions(t *testing.T) {
 
 	a := c.Flag("foo", "foo").
 		HintAction(func() []string {
-		return []string{"opt1", "opt2"}
-	})
+			return []string{"opt1", "opt2"}
+		})
 	a.Enum("opt3", "opt4")
 
 	b := c.Flag("bar", "bar").
 		HintAction(func() []string {
-		return []string{"opt5", "opt6"}
-	})
+			return []string{"opt5", "opt6"}
+		})
 	b.EnumVar(&foo, "opt3", "opt4")
 
 	// Provided HintActions should override automatically generated Enum options.

--- a/parser.go
+++ b/parser.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"unicode/utf8"
 )
 
 type TokenType int
@@ -189,7 +190,8 @@ func (p *ParseContext) Next() *Token {
 		if len(arg) == 1 {
 			return &Token{Index: p.argi, Type: TokenShort}
 		}
-		short := arg[1:2]
+		short_rune, size := utf8.DecodeRuneInString(arg[1:])
+		short := string(short_rune)
 		flag, ok := p.flags.short[short]
 		// Not a known short flag, we'll just return it anyway.
 		if !ok {
@@ -198,14 +200,14 @@ func (p *ParseContext) Next() *Token {
 		} else {
 			// Short flag with combined argument: -fARG
 			token := &Token{p.argi, TokenShort, short}
-			if len(arg) > 2 {
-				p.Push(&Token{p.argi, TokenArg, arg[2:]})
+			if len(arg) > size+1 {
+				p.Push(&Token{p.argi, TokenArg, arg[size+1:]})
 			}
 			return token
 		}
 
-		if len(arg) > 2 {
-			p.args = append([]string{"-" + arg[2:]}, p.args...)
+		if len(arg) > size+1 {
+			p.args = append([]string{"-" + arg[size+1:]}, p.args...)
 		}
 		return &Token{p.argi, TokenShort, short}
 	} else if strings.HasPrefix(arg, "@") {


### PR DESCRIPTION
To solve #146

Modified `func (f *FlagClause) Short(name rune) *FlagClause` to use rune instead of byte.
Modified `func (p *ParseContext) Next() *Token` to parse runes if arg is short flag instead of byte. 