### PR TITLE
WIP : Context feature to help building dynamic flags

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -101,8 +101,10 @@ type ParseContext struct {
 	Elements []*ParseElement
 }
 
-// Get the selected validated commands from a context.
-func (p *ParseContext) SelectedCmds() (selected []string, err error) {
+// SelectedCmds: Get the selected validated commands from a context.
+func (p *ParseContext) SelectedCmds() (selected []*CmdClause, err error) {
+	selected = make([]*CmdClause, 0, len(p.Elements))
+
         for _, element := range p.Elements {
                 switch clause := element.Clause.(type) {
                 case *CmdClause:
@@ -111,7 +113,7 @@ func (p *ParseContext) SelectedCmds() (selected []string, err error) {
                                         return
                                 }
                         }
-                        selected = append(selected, clause.name)
+                        selected = append(selected, clause)
                 }
         }
 

--- a/parser.go
+++ b/parser.go
@@ -101,6 +101,23 @@ type ParseContext struct {
 	Elements []*ParseElement
 }
 
+// Get the selected validated commands from a context.
+func (p *ParseContext) SelectedCmds() (selected []string, err error) {
+        for _, element := range p.Elements {
+                switch clause := element.Clause.(type) {
+                case *CmdClause:
+                        if clause.validator != nil {
+                                if err = clause.validator(clause); err != nil {
+                                        return
+                                }
+                        }
+                        selected = append(selected, clause.name)
+                }
+        }
+
+        return
+}
+
 func (p *ParseContext) nextArg() *ArgClause {
 	if p.argumenti >= len(p.arguments.args) {
 		return nil


### PR DESCRIPTION
I have a tool which dynamically load some flags from other flags. This is done, at ParseContext time.

In short, from a App.ParseContext(...), I'm doing something like this : (simplified)
```go
func MoreFlags(app *kingpin.Application) {
    context, _ = app.ParseContext(os.Args[1:])

    // Identify commands requested.
    cmds, _ := context.SelectedCmds()

    // Do a lot of stuff to validate the context of those commands, and then add more Flags/Clause
}

func main() {
    app := kingpin.New("myapp", "myhelp")
    init(app) // App core flags/clause/commands like --more-flags
    MoreFlags(app) // Load more flags if requested by --more-flags
    switch(app.MustParse()) {
        // ...
    }
}
```

The function created is based on the `func (*Application)setValues(context *ParseContext)`