### PR TITLE
Add link to parsers.go in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ func main() {
 
 Kingpin supports both flag and positional argument parsers for converting to
 Go types. For example, some included parsers are `Int()`, `Float()`,
-`Duration()` and `ExistingFile()`.
+`Duration()` and `ExistingFile()` (see [parsers.go](./parsers.go) for a complete list of included parsers).
 
 Parsers conform to Go's [`flag.Value`](http://godoc.org/flag#Value)
 interface, so any existing implementations will work.


### PR DESCRIPTION
This makes clear that the parsers aforementioned are not the only ones included with kingpin, and are only examples.