### PR TITLE
Added newline to example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ var (
 func main() {
   kingpin.Version("0.0.1")
   kingpin.Parse()
-  fmt.Printf("Would ping: %s with timeout %s and count %d", *ip, *timeout, *count)
+  fmt.Printf("Would ping: %s with timeout %s and count %d\n", *ip, *timeout, *count)
 }
 ```
 


### PR DESCRIPTION
When trying out the examples noticed a missing newline.