### PR TITLE
Fix bug when mixing @file with other args or flags

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -216,11 +216,9 @@ func (p *ParseContext) Next() *Token {
 			return &Token{p.argi, TokenError, err.Error()}
 		}
 		if len(p.args) == 0 {
-			p.args = append(p.args, expanded...)
-		} else if p.argi >= len(p.args) {
-			p.args = append(p.args[:p.argi-1], expanded...)
+			p.args = expanded
 		} else {
-			p.args = append(p.args[:p.argi-1], append(expanded, p.args[p.argi+1:]...)...)
+			p.args = append(expanded, p.args...)
 		}
 		return p.Next()
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -25,6 +25,86 @@ func TestParserExpandFromFile(t *testing.T) {
 	assert.Equal(t, "world", *arg1)
 }
 
+func TestParserExpandFromFileLeadingArg(t *testing.T) {
+	f, err := ioutil.TempFile("", "")
+	assert.NoError(t, err)
+	defer os.Remove(f.Name())
+	f.WriteString("hello\nworld\n")
+	f.Close()
+
+	app := New("test", "")
+	arg0 := app.Arg("arg0", "").String()
+	arg1 := app.Arg("arg1", "").String()
+	arg2 := app.Arg("arg2", "").String()
+
+	_, err = app.Parse([]string{"prefix", "@" + f.Name()})
+	assert.NoError(t, err)
+	assert.Equal(t, "prefix", *arg0)
+	assert.Equal(t, "hello", *arg1)
+	assert.Equal(t, "world", *arg2)
+}
+
+func TestParserExpandFromFileTrailingArg(t *testing.T) {
+	f, err := ioutil.TempFile("", "")
+	assert.NoError(t, err)
+	defer os.Remove(f.Name())
+	f.WriteString("hello\nworld\n")
+	f.Close()
+
+	app := New("test", "")
+	arg0 := app.Arg("arg0", "").String()
+	arg1 := app.Arg("arg1", "").String()
+	arg2 := app.Arg("arg2", "").String()
+
+	_, err = app.Parse([]string{"@" + f.Name(), "suffix"})
+	assert.NoError(t, err)
+	assert.Equal(t, "hello", *arg0)
+	assert.Equal(t, "world", *arg1)
+	assert.Equal(t, "suffix", *arg2)
+}
+
+func TestParserExpandFromFileMultipleSurroundingArgs(t *testing.T) {
+	f, err := ioutil.TempFile("", "")
+	assert.NoError(t, err)
+	defer os.Remove(f.Name())
+	f.WriteString("hello\nworld\n")
+	f.Close()
+
+	app := New("test", "")
+	arg0 := app.Arg("arg0", "").String()
+	arg1 := app.Arg("arg1", "").String()
+	arg2 := app.Arg("arg2", "").String()
+	arg3 := app.Arg("arg3", "").String()
+
+	_, err = app.Parse([]string{"prefix", "@" + f.Name(), "suffix"})
+	assert.NoError(t, err)
+	assert.Equal(t, "prefix", *arg0)
+	assert.Equal(t, "hello", *arg1)
+	assert.Equal(t, "world", *arg2)
+	assert.Equal(t, "suffix", *arg3)
+}
+
+func TestParserExpandFromFileMultipleFlags(t *testing.T) {
+	f, err := ioutil.TempFile("", "")
+	assert.NoError(t, err)
+	defer os.Remove(f.Name())
+	f.WriteString("--flag1=f1\n--flag2=f2\n")
+	f.Close()
+
+	app := New("test", "")
+	flag0 := app.Flag("flag0", "").String()
+	flag1 := app.Flag("flag1", "").String()
+	flag2 := app.Flag("flag2", "").String()
+	flag3 := app.Flag("flag3", "").String()
+
+	_, err = app.Parse([]string{"--flag0=f0", "@" + f.Name(), "--flag3=f3"})
+	assert.NoError(t, err)
+	assert.Equal(t, "f0", *flag0)
+	assert.Equal(t, "f1", *flag1)
+	assert.Equal(t, "f2", *flag2)
+	assert.Equal(t, "f3", *flag3)
+}
+
 func TestParseContextPush(t *testing.T) {
 	app := New("test", "")
 	app.Command("foo", "").Command("bar", "")


### PR DESCRIPTION
Fixes https://github.com/alecthomas/kingpin/issues/191.

The problem was that `p.args` is always modified to contain the *remaining* tokens, rather than all the tokens. We don't need to cross-reference `p.argi` because the current token (the @file to be expanded) has already been removed.