### PR TITLE
trivial: gofmt ./...

### DIFF
--- a/args_test.go
+++ b/args_test.go
@@ -2,8 +2,8 @@ package kingpin
 
 import (
 	"io/ioutil"
-	"testing"
 	"os"
+	"testing"
 
 	"github.com/alecthomas/assert"
 )


### PR DESCRIPTION
Super trivial PR, but running `go fmt ./...` on a vendored copy of kingpin keeps bringing up this change which I have to remember to manually revert.