### PR TITLE
Fix conflict with standard flag package on testing

### DIFF
--- a/global.go
+++ b/global.go
@@ -30,6 +30,9 @@ func init() {
 				globalArgs = append(globalArgs, os.Args[i])
 				os.Args = append(os.Args[:i], os.Args[i+1:]...)
 			} else {
+				if strings.IndexByte(os.Args[i], '=') == -1 {
+					i++ // Current arg doesn't embed value: ignore next arg.
+				}
 				i++
 			}
 		}


### PR DESCRIPTION
This fixes https://github.com/alecthomas/kingpin/issues/167 and https://github.com/alecthomas/kingpin/issues/187.

#### How it works

If it's a test (binary name ends with `.test`), keep flags that doesn't start with `-test.` and remove them from `os.Args` (as we have no control over [flag.Parse](https://golang.org/pkg/flag/#Parse)).

Like that, for a command like `go test -timeout 5s -args --flagforkingpin`, we keep `-test.timeout=5s` for [flag.Parse](https://golang.org/pkg/flag/#Parse) and `--flagforkingpin` for [kingpin.Parse](https://godoc.org/github.com/alecthomas/kingpin#Parse).

---

I also tried defusing [flag.Parse](https://golang.org/pkg/flag/#Parse) by replacing [flag.CommandLine](https://golang.org/pkg/flag/#pkg-variables) with a new [flag.FlagSet](https://golang.org/pkg/flag/#FlagSet) using [PanicOnError](https://golang.org/pkg/flag/#ErrorHandling) instead of [ExitOnError](https://golang.org/pkg/flag/#ErrorHandling) and recover if panic error is `flag provided but not defined`.  
But we loose `-test.` flags.