### PR TITLE
Add optional subcommands

### DIFF
--- a/app.go
+++ b/app.go
@@ -465,7 +465,10 @@ func (a *Application) setValues(context *ParseContext) (selected []string, err e
 		}
 	}
 
-	if lastCmd != nil && len(lastCmd.commands) > 0 {
+	if lastCmd == nil || lastCmd.optionalSubcommands {
+		return
+	}
+	if len(lastCmd.commands) > 0 {
 		return nil, TError("must select a subcommand of '{{.Arg0}}'", V{"Arg0": lastCmd.FullCommand()})
 	}
 

--- a/app_test.go
+++ b/app_test.go
@@ -177,6 +177,15 @@ func TestSubCommandRequired(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestOptionalSubcommandsApp(t *testing.T) {
+	app := newTestApp()
+	c0 := app.Command("c0", "").OptionalSubcommands()
+	c0.Command("c1", "")
+	s, err := app.Parse([]string{"c0"})
+	assert.NoError(t, err)
+	assert.Equal(t, "c0", s)
+}
+
 func TestInterspersedFalse(t *testing.T) {
 	app := newTestApp().Interspersed(false)
 	a1 := app.Arg("a1", "").String()

--- a/cmd.go
+++ b/cmd.go
@@ -177,14 +177,15 @@ type CmdClauseValidator func(*CmdClause) error
 // and either subcommands or positional arguments.
 type CmdClause struct {
 	cmdMixin
-	app            *Application
-	name           string
-	aliases        []string
-	help           string
-	isDefault      bool
-	validator      CmdClauseValidator
-	hidden         bool
-	completionAlts []string
+	app                 *Application
+	name                string
+	aliases             []string
+	help                string
+	isDefault           bool
+	validator           CmdClauseValidator
+	hidden              bool
+	completionAlts      []string
+	optionalSubcommands bool
 }
 
 func newCommand(app *Application, name, help string) *CmdClause {
@@ -259,6 +260,12 @@ func (c *CmdClause) Command(name, help string) *CmdClause {
 	cmd := c.addCommand(name, help)
 	cmd.parent = c
 	return cmd
+}
+
+// OptionalSubcommands makes subcommands optional
+func (c *CmdClause) OptionalSubcommands() *CmdClause {
+	c.optionalSubcommands = true
+	return c
 }
 
 // Default makes this command the default if commands don't match.

--- a/model.go
+++ b/model.go
@@ -106,6 +106,9 @@ type CmdGroupModel struct {
 
 func (c *CmdGroupModel) FlattenedCommands() (out []*CmdModel) {
 	for _, cmd := range c.Commands {
+		if cmd.OptionalSubcommands {
+			out = append(out, cmd)
+		}
 		if len(cmd.Commands) == 0 {
 			out = append(out, cmd)
 		}
@@ -115,13 +118,14 @@ func (c *CmdGroupModel) FlattenedCommands() (out []*CmdModel) {
 }
 
 type CmdModel struct {
-	Name    string
-	Aliases []string
-	Help    string
-	Depth   int
-	Hidden  bool
-	Default bool
-	Parent  *CmdModel
+	Name                string
+	Aliases             []string
+	Help                string
+	Depth               int
+	Hidden              bool
+	Default             bool
+	OptionalSubcommands bool
+	Parent              *CmdModel
 	*FlagGroupModel
 	*ArgGroupModel
 	*CmdGroupModel
@@ -265,15 +269,16 @@ func (c *CmdClause) Model(parent *CmdModel) *CmdModel {
 		depth++
 	}
 	cmd := &CmdModel{
-		Name:           c.name,
-		Parent:         parent,
-		Aliases:        c.aliases,
-		Help:           c.help,
-		Depth:          depth,
-		Hidden:         c.hidden,
-		Default:        c.isDefault,
-		FlagGroupModel: c.flagGroup.Model(),
-		ArgGroupModel:  c.argGroup.Model(),
+		Name:                c.name,
+		Parent:              parent,
+		Aliases:             c.aliases,
+		Help:                c.help,
+		Depth:               depth,
+		Hidden:              c.hidden,
+		Default:             c.isDefault,
+		OptionalSubcommands: c.optionalSubcommands,
+		FlagGroupModel:      c.flagGroup.Model(),
+		ArgGroupModel:       c.argGroup.Model(),
 	}
 	cmd.CmdGroupModel = c.cmdGroup.Model(cmd)
 	return cmd

--- a/parser.go
+++ b/parser.go
@@ -132,6 +132,23 @@ type ParseContext struct {
 	Elements ParseElements
 }
 
+// LastCmd returns true if the element is the last (sub)command
+// being evaluated.
+func (p *ParseContext) LastCmd(element *ParseElement) bool {
+	lastCmdIndex := -1
+	eIndex := -2
+	for i, e := range p.Elements {
+		if element == e {
+			eIndex = i
+		}
+
+		if e.OneOf.Cmd != nil {
+			lastCmdIndex = i
+		}
+	}
+	return lastCmdIndex == eIndex
+}
+
 func (p *ParseContext) nextArg() *Clause {
 	if p.argumenti >= len(p.arguments.args) {
 		return nil

--- a/parser_test.go
+++ b/parser_test.go
@@ -6,6 +6,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func cmdElem() *ParseElement {
+	return &ParseElement{
+		OneOf: OneOfClause{
+			Cmd: &CmdClause{},
+		},
+	}
+}
+
 func TestParseContextPush(t *testing.T) {
 	c := tokenize([]string{"foo", "bar"}, false)
 	a := c.Next()
@@ -18,4 +26,22 @@ func TestParseContextPush(t *testing.T) {
 	assert.Equal(t, "foo", a.Value)
 	b = c.Next()
 	assert.Equal(t, "bar", b.Value)
+}
+
+func TestLastCmd(t *testing.T) {
+	e := cmdElem()
+	pc := &ParseContext{
+		Elements: []*ParseElement{e, cmdElem(), cmdElem()},
+	}
+	assert.Equal(t, false, pc.LastCmd(e))
+
+	pc = &ParseContext{
+		Elements: []*ParseElement{cmdElem(), e, cmdElem()},
+	}
+	assert.Equal(t, false, pc.LastCmd(e))
+
+	pc = &ParseContext{
+		Elements: []*ParseElement{cmdElem(), cmdElem(), e},
+	}
+	assert.Equal(t, true, pc.LastCmd(e))
 }

--- a/usage_test.go
+++ b/usage_test.go
@@ -24,6 +24,72 @@ func TestFormatTwoColumns(t *testing.T) {
 	assert.Equal(t, expected, buf.String())
 }
 
+func TestRequiredSubcommandsUsage(t *testing.T) {
+	var buf bytes.Buffer
+
+	a := New("test", "Test").Writers(&buf, ioutil.Discard).Terminate(nil)
+	c0 := a.Command("c0", "c0info")
+	c0.Command("c1", "c1info")
+	_, err := a.Parse(nil)
+	assert.Error(t, err)
+
+	expectedStr := `
+usage: test [<flags>] <command>
+
+Test
+
+
+Flags:
+  --help  Show context-sensitive help.
+
+Commands:
+  help [<command> ...]
+    Show help.
+
+
+  c0 c1
+    c1info
+
+
+`
+	assert.Equal(t, expectedStr, buf.String())
+}
+
+func TestOptionalSubcommandsUsage(t *testing.T) {
+	var buf bytes.Buffer
+
+	a := New("test", "Test").Writers(&buf, ioutil.Discard).Terminate(nil)
+	c0 := a.Command("c0", "c0info").OptionalSubcommands()
+	c0.Command("c1", "c1info")
+	_, err := a.Parse(nil)
+	assert.Error(t, err)
+
+	expectedStr := `
+usage: test [<flags>] <command>
+
+Test
+
+
+Flags:
+  --help  Show context-sensitive help.
+
+Commands:
+  help [<command> ...]
+    Show help.
+
+
+  c0
+    c0info
+
+
+  c0 c1
+    c1info
+
+
+`
+	assert.Equal(t, expectedStr, buf.String())
+}
+
 func TestFormatTwoColumnsWide(t *testing.T) {
 	samples := [][2]string{
 		{strings.Repeat("x", 29), "29 chars"},


### PR DESCRIPTION
Also introduces a helper function in the ParseContext that determines
if a ParseElement is the currently executing command.