### PR TITLE
Import from gopkg like the other examples

### DIFF
--- a/_examples/completion/main.go
+++ b/_examples/completion/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/alecthomas/kingpin"
+	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 func listHosts() []string {


### PR DESCRIPTION
This was the only example not importing from gopkg. When trying multiple examples this one would not work because it was not available locally. It took me a while to understand what was happening.