### PR TITLE
Implement a config resolver

### DIFF
--- a/model.go
+++ b/model.go
@@ -44,16 +44,17 @@ func (f *FlagGroupModel) FlagSummary() string {
 }
 
 type ClauseModel struct {
-	Name        string
-	Help        string
-	Short       rune
-	Default     []string
-	Envar       string
-	PlaceHolder string
-	Required    bool
-	Hidden      bool
-	Value       Value
-	Cumulative  bool
+	Name              string
+	Help              string
+	Short             rune
+	Default           []string
+	Envar             string
+	ConfigResolverKey string
+	PlaceHolder       string
+	Required          bool
+	Hidden            bool
+	Value             Value
+	Cumulative        bool
 }
 
 func (c *ClauseModel) String() string {
@@ -251,16 +252,17 @@ func (f *flagGroup) Model() *FlagGroupModel {
 func (f *Clause) Model() *ClauseModel {
 	_, cumulative := f.value.(cumulativeValue)
 	return &ClauseModel{
-		Name:        f.name,
-		Help:        f.help,
-		Short:       f.shorthand,
-		Default:     f.defaultValues,
-		Envar:       f.envar,
-		PlaceHolder: f.placeholder,
-		Required:    f.required,
-		Hidden:      f.hidden,
-		Value:       f.value,
-		Cumulative:  cumulative,
+		Name:              f.name,
+		Help:              f.help,
+		Short:             f.shorthand,
+		Default:           f.defaultValues,
+		Envar:             f.envar,
+		ConfigResolverKey: f.resolverKey,
+		PlaceHolder:       f.placeholder,
+		Required:          f.required,
+		Hidden:            f.hidden,
+		Value:             f.value,
+		Cumulative:        cumulative,
 	}
 }
 

--- a/parser.go
+++ b/parser.go
@@ -119,6 +119,7 @@ func (p ParseElements) ArgMap() map[string]*ParseElement {
 // any).
 type ParseContext struct {
 	SelectedCommand *CmdClause
+	Resolvers       []*ConfigResolver
 	ignoreDefault   bool
 	argsOnly        bool
 	peek            []*Token
@@ -130,6 +131,11 @@ type ParseContext struct {
 	argumenti       int // Cursor into arguments
 	// Flags, arguments and commands encountered and collected during parse.
 	Elements ParseElements
+}
+
+// A ConfigResolver retrieves configuration from an external source
+type ConfigResolver interface {
+	Resolve(string, *ParseContext) string
 }
 
 // LastCmd returns true if the element is the last (sub)command

--- a/struct.go
+++ b/struct.go
@@ -35,6 +35,7 @@ func (c *cmdMixin) fromStruct(clause *CmdClause, v interface{}) error { // nolin
 		required := tag.Get("required")
 		hidden := tag.Get("hidden")
 		env := tag.Get("env")
+		resolverKey := tag.Get("resolverKey")
 		enum := tag.Get("enum")
 		name := strings.ToLower(strings.Join(camelCase(ft.Name), "-"))
 		if tag.Get("long") != "" {
@@ -97,6 +98,9 @@ func (c *cmdMixin) fromStruct(clause *CmdClause, v interface{}) error { // nolin
 		}
 		if env != "" {
 			clause = clause.Envar(env)
+		}
+		if resolverKey != "" {
+			clause = clause.ConfigResolverKey(resolverKey)
 		}
 		ptr := field.Addr().Interface()
 		if ft.Type == reflect.TypeOf(time.Duration(0)) {


### PR DESCRIPTION
As discussed in #208 and on gitter: This PR implements a method for populating flags from an user-defined external source, such as a config file. Some properties:
- This source has lower priority than flags set on the command-line, and envars. 
- Multiple resolvers can be added, and they will be used in the order added, until the first match is found. 
- The lookup is performed using the name of the flag, unless the user sets a custom one. 
- It is possible to disable usage of the resolvers on a per-flag basis.

Things I'm not sure about and would appreciate some discussion around:
- Currently it is not possible to add a resolver directly on a flag. I don't see that this would be useful, but it wouldn't be hard to add if there is a use-case?
- I did not check in any implementations for users, but possibly it would be useful to ship some standard ones such as yaml/json file sources? Probably in a separate package in that case?
- Errors must be handled in the `Resolve` method. I'm not sure how an error would best be handled if propagated back up the stack? But I guess someone will implement a remote call resolver, which could lead to all sorts of interesting errors, so maybe it would be better to have it after all... 

(Also, naming, of course)