### PR TITLE
Fix setDefaults to exit early on `--help`

### DIFF
--- a/app.go
+++ b/app.go
@@ -402,6 +402,9 @@ func (a *Application) setDefaults(context *ParseContext) error {
 	flagElements := map[string]*ParseElement{}
 	for _, element := range context.Elements {
 		if flag, ok := element.Clause.(*FlagClause); ok {
+			if flag.name == "help" {
+				return nil
+			}
 			flagElements[flag.name] = element
 		}
 	}


### PR DESCRIPTION
When `--help` is passed, there is no need to set and validate default
flags/arguments, since we are just going to print the usage text and
exit.

This fixes #218.