### PR TITLE
Don't show additional-flags token in usage if all flags are required

### DIFF
--- a/model.go
+++ b/model.go
@@ -16,7 +16,7 @@ func (f *FlagGroupModel) FlagSummary() string {
 	out := []string{}
 	count := 0
 	for _, flag := range f.Flags {
-		if flag.Name != "help" {
+		if !strings.HasPrefix(flag.Name, "help") && !strings.HasPrefix(flag.Name, "completion") {
 			count++
 		}
 		if flag.Required {

--- a/model.go
+++ b/model.go
@@ -8,6 +8,17 @@ import (
 
 // Data model for Kingpin command-line structure.
 
+var (
+	ignoreInCount = map[string]bool{
+		"help":                   true,
+		"help-long":              true,
+		"help-man":               true,
+		"completion-bash":        true,
+		"completion-script-bash": true,
+		"completion-script-zsh":  true,
+	}
+)
+
 type FlagGroupModel struct {
 	Flags []*FlagModel
 }
@@ -17,15 +28,6 @@ func (f *FlagGroupModel) FlagSummary() string {
 	count := 0
 
 	for _, flag := range f.Flags {
-
-		ignoreInCount := map[string]bool{
-			"help":                   true,
-			"help-long":              true,
-			"help-man":               true,
-			"completion-bash":        true,
-			"completion-script-bash": true,
-			"completion-script-zsh":  true,
-		}
 
 		if !ignoreInCount[flag.Name] {
 			count++

--- a/model.go
+++ b/model.go
@@ -15,10 +15,22 @@ type FlagGroupModel struct {
 func (f *FlagGroupModel) FlagSummary() string {
 	out := []string{}
 	count := 0
+
 	for _, flag := range f.Flags {
-		if !strings.HasPrefix(flag.Name, "help") && !strings.HasPrefix(flag.Name, "completion") {
+
+		ignoreInCount := map[string]bool{
+			"help":                   true,
+			"help-long":              true,
+			"help-man":               true,
+			"completion-bash":        true,
+			"completion-script-bash": true,
+			"completion-script-zsh":  true,
+		}
+
+		if !ignoreInCount[flag.Name] {
 			count++
 		}
+
 		if flag.Required {
 			if flag.IsBoolFlag() {
 				out = append(out, fmt.Sprintf("--[no-]%s", flag.Name))


### PR DESCRIPTION
As completion- and help-flags are not ignored when parsed in FlagSummary(), ```[<flags>]``` token will always be displayed in usage line even if there are no more possible flags to choose from.