### PR TITLE
Potential solution for ignoring unknown flags

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -119,14 +119,17 @@ loop:
 			// Move beyond unknown
 			if unknown {
 				fmt.Printf("Ignoring unknown flag '%s'\n", flagToken)
-				context.Next()
-				switch context.Peek().Type {
-				case TokenEOL, TokenLong, TokenShort:
-					continue
-				default:
-					context.Next() // Moves beyond unknown token argument
+
+				// Advance to next long or short flag, or EOL
+				for {
+					context.Next()
+					switch context.Peek().Type {
+					case TokenEOL, TokenLong, TokenShort:
+						continue loop
+					default:
+						context.Next() // Moves beyond unknown token argument
+					}
 				}
-				continue
 			}
 
 			context.Next()

--- a/global.go
+++ b/global.go
@@ -16,6 +16,8 @@ var (
 	VersionFlag = CommandLine.VersionFlag
 	// Whether to file expansion with '@' is enabled.
 	EnableFileExpansion = true
+	// IgnoreUnknown ignores unrecognized tokens
+	IgnoreUnknown = false
 )
 
 // Command adds a new command to the default parser.


### PR DESCRIPTION
A potential solution for ignoring unknown flags. This is something we've run into a need for with automated deployments of updates. 

The basics are that if the parser runs into an unknown `TokenShort` or `TokenLong` and the option to ignore unknown is set, it advances the context - potentially past a trailing argument to the flag.

This doesn't break any tests (but doesn't add any yet).

I know the idea was closed in #237 but I figured I'd have a go at it and submit a PR for discussion. Thanks!