### PR TITLE
Improve the shell completion templates

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -237,26 +237,27 @@ _{{.App.Name}}_bash_autocomplete() {
     local cur prev opts base
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
-    opts=$( ${COMP_WORDS[0]} --completion-bash ${COMP_WORDS[@]:1:$COMP_CWORD} )
+    opts=$( ${COMP_WORDS[0]} --completion-bash "${COMP_WORDS[@]:1:$COMP_CWORD}" )
     COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
     return 0
 }
-complete -F _{{.App.Name}}_bash_autocomplete {{.App.Name}}
+complete -F _{{.App.Name}}_bash_autocomplete -o default {{.App.Name}}
 
 `
 
 var ZshCompletionTemplate = `
 #compdef {{.App.Name}}
-autoload -U compinit && compinit
-autoload -U bashcompinit && bashcompinit
 
-_{{.App.Name}}_bash_autocomplete() {
-    local cur prev opts base
-    COMPREPLY=()
-    cur="${COMP_WORDS[COMP_CWORD]}"
-    opts=$( ${COMP_WORDS[0]} --completion-bash ${COMP_WORDS[@]:1:$COMP_CWORD} )
-    COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
-    return 0
+_{{.App.Name}}() {
+    local matches=($(${words[1]} --completion-bash "${(@)words[1,$CURRENT]}"))
+    compadd -a matches
+
+    if [[ $compstate[nmatches] -eq 0 && $words[$CURRENT] != -* ]]; then
+        _files
+    fi
 }
-complete -F _{{.App.Name}}_bash_autocomplete {{.App.Name}}
+
+if [[ "$(basename -- ${(%):-%x})" != "_{{.App.Name}}" ]]; then
+    compdef _{{.App.Name}} {{.App.Name}}
+fi
 `


### PR DESCRIPTION
* Complete file names when there are no matches.
* Convert to a native Zsh completion script .
* Don't call `compinit`. That is up to the user. Calling it resets the completion system.
* Quote array expansion with `@` to avoid dropping empty entries.
* The Zsh completion script can both be `eval`-ed and installed into `fpath`.