### PR TITLE
Fix Enums Parsing Not Allowing More Than One Value

### DIFF
--- a/values.go
+++ b/values.go
@@ -381,13 +381,18 @@ func newEnumsFlag(target *[]string, options ...string) *enumsValue {
 }
 
 func (s *enumsValue) Set(value string) error {
-	for _, v := range s.options {
-		if v == value {
-			*s.value = append(*s.value, value)
-			return nil
+	vals := strings.Split(value, ",")
+
+	for _, val := range vals {
+		trimmedVal := strings.TrimSpace(val)
+		if enumOption(val, s.options) {
+			*s.value = append(*s.value, trimmedVal)
+		} else {
+			return fmt.Errorf("enum value must be one of %s, got '%s'", strings.Join(s.options, ","), trimmedVal)
 		}
 	}
-	return fmt.Errorf("enum value must be one of %s, got '%s'", strings.Join(s.options, ","), value)
+
+	return nil
 }
 
 func (e *enumsValue) Get() interface{} {
@@ -400,6 +405,16 @@ func (s *enumsValue) String() string {
 
 func (s *enumsValue) IsCumulative() bool {
 	return true
+}
+
+func enumOption(value string, options []string) bool {
+	for _, v := range options {
+		if v == value {
+			return true
+		}
+	}
+
+	return false
 }
 
 // -- units.Base2Bytes Value

--- a/values_test.go
+++ b/values_test.go
@@ -47,6 +47,22 @@ func TestEnumVar(t *testing.T) {
 	assert.Equal(t, "one", a)
 }
 
+func TestEnums(t *testing.T) {
+	app := New("", "")
+	a := app.Arg("a", "").Enums("one", "two", "three")
+	_, err := app.Parse([]string{"moo"})
+	assert.Error(t, err)
+	// Check that we get the error even if only one value is not a valid enum option
+	_, err = app.Parse([]string{"one", "two", "moo"})
+	assert.Error(t, err)
+
+	app = New("", "")
+	a = app.Arg("a", "").Enums("one", "two", "three")
+	_, err = app.Parse([]string{"one", "two"})
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, *a, []string{"one", "two"}, "elements %s", *a)
+}
+
 func TestCounter(t *testing.T) {
 	app := New("", "")
 	c := app.Flag("f", "").Counter()


### PR DESCRIPTION
## Problem

Trying to use `Enums`, I noticed that it essentially behaved like `Enum` would but would return a `[]string` instead of a `string`. I intuitively assumed that `Enums` would be to return a `[]string` for which all values had to be one of the possible enum options. 

Example flag definition:
```
kingpin.Flag("animals", "The animals to spot").Required().Enums("dog", "cat", "bird", "fish")
```

Using it with a list of values from the valid options results in:
```
./test --animals=dog,cat
error: enum value must be one of dog,cat,bird,fish, got dog,cat
```

## Solution

Changing the parsing of `enumsValue` in `func (s *enumsValue) Set(value string) error {` so that it first splits by `,` and then checks that all arg values are a valid enum options. On the non-enum value encountered, an error is returned.

With this change, I can now do:
```
animals = kingpin.Flag("animals", "The animals to spot").Required().Enums("dog", "cat", "bird", "fish")
...
fmt.Printf("animals: %s\n", strings.Join(*animals, ","))

> ./test --animals=dog,cat
> animals: dog,cat
```
