### PR TITLE
Add possibility to use custom functions in the usage template

### DIFF
--- a/app.go
+++ b/app.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"text/template"
 )
 
 var (
@@ -32,6 +33,7 @@ type Application struct {
 	errorWriter    io.Writer // Destination for errors.
 	usageWriter    io.Writer // Destination for usage
 	usageTemplate  string
+	usageFuncs     template.FuncMap
 	validator      ApplicationValidator
 	terminate      func(status int) // See Terminate()
 	noInterspersed bool             // can flags be interspersed with args (or must they come first)
@@ -150,6 +152,12 @@ func (a *Application) UsageWriter(w io.Writer) *Application {
 // information. The default is UsageTemplate.
 func (a *Application) UsageTemplate(template string) *Application {
 	a.usageTemplate = template
+	return a
+}
+
+// UsageFuncs adds extra functions that can be used in the usage template.
+func (a *Application) UsageFuncs(funcs template.FuncMap) *Application {
+	a.usageFuncs = funcs
 	return a
 }
 

--- a/usage.go
+++ b/usage.go
@@ -190,6 +190,10 @@ func (a *Application) UsageForContextWithTemplate(context *ParseContext, indent 
 			return string(c)
 		},
 	}
+	for k, v := range a.usageFuncs {
+		funcs[k] = v
+	}
+
 	t, err := template.New("usage").Funcs(funcs).Parse(tmpl)
 	if err != nil {
 		return err

--- a/usage_test.go
+++ b/usage_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+	"text/template"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -62,4 +63,17 @@ func TestHiddenCommand(t *testing.T) {
 		assert.NotContains(t, usage, "hidden")
 		assert.Contains(t, usage, "visible")
 	}
+}
+
+func TestUsageFuncs(t *testing.T) {
+	var buf bytes.Buffer
+	a := New("test", "Test").Writer(&buf).Terminate(nil)
+	tpl := `{{ add 2 1 }}`
+	a.UsageTemplate(tpl)
+	a.UsageFuncs(template.FuncMap{
+		"add": func(x, y int) int { return x + y },
+	})
+	a.Parse([]string{"--help"})
+	usage := buf.String()
+	assert.Equal(t, "3", usage)
 }


### PR DESCRIPTION
Hi,

I had a usecase (https://github.com/secrethub/secrethub-cli/pull/71) where I'd like to have some extra functions available in the usage template. How do you feel about making it possible to add some custom functions?