### PR TITLE
The example in documentation is not working for zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,14 +556,14 @@ is improved for bug fixed.
 Alternatively, instruct your users to add an additional statement to
 their `bash_profile` (or equivalent):
 
-```
+```bash
 eval "$(your-cli-tool --completion-script-bash)"
 ```
 
 Or for ZSH
 
-```
-eval "$(your-cli-tool --completion-script-zsh)"
+```bash
+your-cli-tool --completion-script-zsh | source /dev/stdin
 ```
 
 #### Additional API


### PR DESCRIPTION
eval does nothing since the generated completion starts with a #