### PR TITLE
usage: fix formatCmdUsage

### DIFF
--- a/usage.go
+++ b/usage.go
@@ -64,11 +64,11 @@ func formatAppUsage(app *ApplicationModel) string {
 
 func formatCmdUsage(app *ApplicationModel, cmd *CmdModel) string {
 	s := []string{app.Name, cmd.String()}
-	if len(app.Flags) > 0 {
-		s = append(s, app.FlagSummary())
+	if len(cmd.Flags) > 0 {
+		s = append(s, cmd.FlagSummary())
 	}
-	if len(app.Args) > 0 {
-		s = append(s, app.ArgSummary())
+	if len(cmd.Args) > 0 {
+		s = append(s, cmd.ArgSummary())
 	}
 	return strings.Join(s, " ")
 }


### PR DESCRIPTION
This fixes the behaviour of formatCmdUsage

- before: it outputs the apps flags and arguments
- after: it outputs the commands flags and arguments

Template file to test:

``` tmpl
{{define "FormatCommands"}}\
{{range .FlattenedCommands}}
## {{formatCmdUsage $ .}}
{{template "FormatUsage" .}}\
{{end}}\
{{end}}\
\
{{define "FormatUsage"}}
{{if .Help}}\
{{.Help|Wrap 0}}\
{{end}}\
{{end}}\
\
{{if not .Context.SelectedCommand}}\
# <command> [<args> ...]
{{template "FormatUsage" .App}}
{{end}}

{{if .Context.Flags}}
Flags:
{{.Context.Flags|FlagsToTwoColumns|FormatTwoColumns}}
{{end}}

{{if .Context.Args}}
Args:
{{.Context.Args|ArgsToTwoColumns|FormatTwoColumns}}
{{end}}

{{if .Context.SelectedCommand}}
{{if len .Context.SelectedCommand.Commands}}
Subcommands:
{{template "FormatCommands" .Context.SelectedCommand}}
{{end}}\
{{else if .App.Commands}}
Commands:
{{template "FormatCommands" .App}}
{{end}}
```
