### PR TITLE
Add a long command help text to the usage template context

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -221,6 +221,7 @@ type CmdClause struct {
 	name           string
 	aliases        []string
 	help           string
+	helpLong       string
 	isDefault      bool
 	validator      CmdClauseValidator
 	hidden         bool
@@ -300,5 +301,13 @@ func (c *CmdClause) init() error {
 
 func (c *CmdClause) Hidden() *CmdClause {
 	c.hidden = true
+	return c
+}
+
+// HelpLong adds a long help text, which can be used in usage templates.
+// For example, to use a longer help text in the command-specific help
+// than in the apps root help.
+func (c *CmdClause) HelpLong(help string) *CmdClause {
+	c.helpLong = help
 	return c
 }

--- a/model.go
+++ b/model.go
@@ -137,6 +137,7 @@ type CmdModel struct {
 	Name        string
 	Aliases     []string
 	Help        string
+	HelpLong    string
 	FullCommand string
 	Depth       int
 	Hidden      bool
@@ -230,6 +231,7 @@ func (c *CmdClause) Model() *CmdModel {
 		Name:           c.name,
 		Aliases:        c.aliases,
 		Help:           c.help,
+		HelpLong:       c.helpLong,
 		Depth:          depth,
 		Hidden:         c.hidden,
 		Default:        c.isDefault,

--- a/usage_test.go
+++ b/usage_test.go
@@ -77,3 +77,17 @@ func TestUsageFuncs(t *testing.T) {
 	usage := buf.String()
 	assert.Equal(t, "3", usage)
 }
+
+func TestCmdClause_HelpLong(t *testing.T) {
+	var buf bytes.Buffer
+	tpl := `{{define "FormatUsage"}}{{.HelpLong}}{{end}}\
+{{template "FormatUsage" .Context.SelectedCommand}}`
+
+	a := New("test", "Test").Writer(&buf).Terminate(nil)
+	a.UsageTemplate(tpl)
+	a.Command("command", "short help text").HelpLong("long help text")
+
+	a.Parse([]string{"command", "--help"})
+	usage := buf.String()
+	assert.Equal(t, "long help text", usage)
+}


### PR DESCRIPTION
This can for example be used to display a longer help text in the command-specific help than in the apps root help.