### PR TITLE
Remove ineffectual assignments in tests

### DIFF
--- a/args_test.go
+++ b/args_test.go
@@ -38,7 +38,7 @@ func TestArgMultipleRequired(t *testing.T) {
 	assert.Error(t, err)
 	_, err = app.Parse([]string{"A", "B"})
 	assert.NoError(t, err)
-	_, err = app.Parse([]string{"--version"})
+	app.Parse([]string{"--version"})
 	assert.True(t, terminated)
 }
 

--- a/flags_test.go
+++ b/flags_test.go
@@ -66,7 +66,7 @@ func TestRequiredFlag(t *testing.T) {
 	assert.NoError(t, err)
 	_, err = app.Parse([]string{})
 	assert.Error(t, err)
-	_, err = app.Parse([]string{"--version"})
+	app.Parse([]string{"--version"})
 	assert.Equal(t, 1, exits)
 }
 


### PR DESCRIPTION
Don't assign a value to err if we don't end up checking it.