### PR TITLE
Don't wrap string slice in another

### DIFF
--- a/envar.go
+++ b/envar.go
@@ -28,15 +28,13 @@ func (e *envarMixin) GetEnvarValue() string {
 }
 
 func (e *envarMixin) GetSplitEnvarValue() []string {
-	values := make([]string, 0)
-
 	envarValue := e.GetEnvarValue()
 	if envarValue == "" {
-		return values
+		return []string{}
 	}
 
 	// Split by new line to extract multiple values, if any.
 	trimmed := envVarValuesTrimmer.ReplaceAllString(envarValue, "")
 
-	return append(values, envVarValuesSplitter.Split(trimmed, -1)...)
+	return envVarValuesSplitter.Split(trimmed, -1)
 }


### PR DESCRIPTION
Directly return the string slice returned by Split, no need to
wrap this in another slice.