### PR TITLE
Add possibility to hide arguments from usage/help

### DIFF
--- a/args.go
+++ b/args.go
@@ -71,6 +71,7 @@ type ArgClause struct {
 	name          string
 	help          string
 	defaultValues []string
+	hidden        bool
 	required      bool
 }
 
@@ -118,6 +119,12 @@ func (a *ArgClause) consumesRemainder() bool {
 		return r.IsCumulative()
 	}
 	return false
+}
+
+// Hidden hides the argument from usage but still allows it to be used.
+func (a *ArgClause) Hidden() *ArgClause {
+	a.hidden = true
+	return a
 }
 
 // Required arguments must be input by the user. They can not have a Default() value provided.

--- a/model.go
+++ b/model.go
@@ -115,6 +115,7 @@ type ArgModel struct {
 	Default  []string
 	Envar    string
 	Required bool
+	Hidden   bool
 	Value    Value
 }
 
@@ -195,6 +196,7 @@ func (a *ArgClause) Model() *ArgModel {
 		Default:  a.defaultValues,
 		Envar:    a.envar,
 		Required: a.required,
+		Hidden:   a.hidden,
 		Value:    a.value,
 	}
 }

--- a/usage.go
+++ b/usage.go
@@ -162,11 +162,13 @@ func (a *Application) UsageForContextWithTemplate(context *ParseContext, indent 
 		"ArgsToTwoColumns": func(a []*ArgModel) [][2]string {
 			rows := [][2]string{}
 			for _, arg := range a {
-				s := "<" + arg.Name + ">"
-				if !arg.Required {
-					s = "[" + s + "]"
+				if !arg.Hidden {
+					s := "<" + arg.Name + ">"
+					if !arg.Required {
+						s = "[" + s + "]"
+					}
+					rows = append(rows, [2]string{s, arg.Help})
 				}
-				rows = append(rows, [2]string{s, arg.Help})
 			}
 			return rows
 		},


### PR DESCRIPTION
This is for example useful when a command accepts an argument for
backwards compatability purposes only. As in this case the argument
is no longer the recommended way to do things, it should not be
included in the usage output.