### PR TITLE
Add PlaceHolder functionality for arguments

### DIFF
--- a/args.go
+++ b/args.go
@@ -71,6 +71,7 @@ type ArgClause struct {
 	name          string
 	help          string
 	defaultValues []string
+	placeholder   string
 	hidden        bool
 	required      bool
 }
@@ -124,6 +125,13 @@ func (a *ArgClause) consumesRemainder() bool {
 // Hidden hides the argument from usage but still allows it to be used.
 func (a *ArgClause) Hidden() *ArgClause {
 	a.hidden = true
+	return a
+}
+
+// PlaceHolder sets the place-holder string used for arg values in the help. The
+// default behaviour is to use the arg name between < > brackets.
+func (a *ArgClause) PlaceHolder(value string) *ArgClause {
+	a.placeholder = value
 	return a
 }
 

--- a/model.go
+++ b/model.go
@@ -98,7 +98,12 @@ func (a *ArgGroupModel) ArgSummary() string {
 	depth := 0
 	out := []string{}
 	for _, arg := range a.Args {
-		h := "<" + arg.Name + ">"
+		var h string
+		if arg.PlaceHolder != "" {
+			h = arg.PlaceHolder
+		} else {
+			h = "<" + arg.Name + ">"
+		}
 		if !arg.Required {
 			h = "[" + h
 			depth++
@@ -110,13 +115,14 @@ func (a *ArgGroupModel) ArgSummary() string {
 }
 
 type ArgModel struct {
-	Name     string
-	Help     string
-	Default  []string
-	Envar    string
-	Required bool
-	Hidden   bool
-	Value    Value
+	Name        string
+	Help        string
+	Default     []string
+	Envar       string
+	PlaceHolder string
+	Required    bool
+	Hidden      bool
+	Value       Value
 }
 
 func (a *ArgModel) String() string {
@@ -191,13 +197,14 @@ func (a *argGroup) Model() *ArgGroupModel {
 
 func (a *ArgClause) Model() *ArgModel {
 	return &ArgModel{
-		Name:     a.name,
-		Help:     a.help,
-		Default:  a.defaultValues,
-		Envar:    a.envar,
-		Required: a.required,
-		Hidden:   a.hidden,
-		Value:    a.value,
+		Name:        a.name,
+		Help:        a.help,
+		Default:     a.defaultValues,
+		Envar:       a.envar,
+		PlaceHolder: a.placeholder,
+		Required:    a.required,
+		Hidden:      a.hidden,
+		Value:       a.value,
 	}
 }
 

--- a/templates.go
+++ b/templates.go
@@ -3,7 +3,7 @@ package kingpin
 // Default usage template.
 var DefaultUsageTemplate = `{{define "FormatCommand"}}\
 {{if .FlagSummary}} {{.FlagSummary}}{{end}}\
-{{range .Args}} {{if not .Required}}[{{end}}<{{.Name}}>{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}\
+{{range .Args}}{{if not .Hidden}} {{if not .Required}}[{{end}}{{if .PlaceHolder}}{{.PlaceHolder}}{{else}}<{{.Name}}>{{end}}{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}{{end}}\
 {{end}}\
 
 {{define "FormatCommands"}}\
@@ -50,7 +50,7 @@ Commands:
 // Usage template where command's optional flags are listed separately
 var SeparateOptionalFlagsUsageTemplate = `{{define "FormatCommand"}}\
 {{if .FlagSummary}} {{.FlagSummary}}{{end}}\
-{{range .Args}} {{if not .Required}}[{{end}}<{{.Name}}>{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}\
+{{range .Args}}{{if not .Hidden}} {{if not .Required}}[{{end}}{{if .PlaceHolder}}{{.PlaceHolder}}{{else}}<{{.Name}}>{{end}}{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}{{end}}\
 {{end}}\
 
 {{define "FormatCommands"}}\
@@ -101,7 +101,7 @@ Commands:
 // Usage template with compactly formatted commands.
 var CompactUsageTemplate = `{{define "FormatCommand"}}\
 {{if .FlagSummary}} {{.FlagSummary}}{{end}}\
-{{range .Args}} {{if not .Required}}[{{end}}<{{.Name}}>{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}\
+{{range .Args}}{{if not .Hidden}} {{if not .Required}}[{{end}}{{if .PlaceHolder}}{{.PlaceHolder}}{{else}}<{{.Name}}>{{end}}{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}{{end}}\
 {{end}}\
 
 {{define "FormatCommandList"}}\
@@ -158,7 +158,7 @@ var ManPageTemplate = `{{define "FormatFlags"}}\
 
 {{define "FormatCommand"}}\
 {{if .FlagSummary}} {{.FlagSummary}}{{end}}\
-{{range .Args}} {{if not .Required}}[{{end}}<{{.Name}}{{if .Default}}*{{end}}>{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}\
+{{range .Args}}{{if not .Hidden}} {{if not .Required}}[{{end}}{{if .PlaceHolder}}{{.PlaceHolder}}{{else}}<{{.Name}}>{{end}}{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}{{end}}\
 {{end}}\
 
 {{define "FormatCommands"}}\
@@ -196,7 +196,7 @@ var ManPageTemplate = `{{define "FormatFlags"}}\
 // Default usage template.
 var LongHelpTemplate = `{{define "FormatCommand"}}\
 {{if .FlagSummary}} {{.FlagSummary}}{{end}}\
-{{range .Args}} {{if not .Required}}[{{end}}<{{.Name}}>{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}\
+{{range .Args}}{{if not .Hidden}} {{if not .Required}}[{{end}}{{if .PlaceHolder}}{{.PlaceHolder}}{{else}}<{{.Name}}>{{end}}{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}{{end}}\
 {{end}}\
 
 {{define "FormatCommands"}}\

--- a/usage.go
+++ b/usage.go
@@ -163,7 +163,12 @@ func (a *Application) UsageForContextWithTemplate(context *ParseContext, indent 
 			rows := [][2]string{}
 			for _, arg := range a {
 				if !arg.Hidden {
-					s := "<" + arg.Name + ">"
+					var s string
+					if arg.PlaceHolder != "" {
+						s = arg.PlaceHolder
+					} else {
+						s = "<" + arg.Name + ">"
+					}
 					if !arg.Required {
 						s = "[" + s + "]"
 					}


### PR DESCRIPTION
Just like you can set a placeholder for flags, you can now set
a placeholder for arguments, to be used in the help of the command
instead of the arg name.

This can for example be used for compound arguments; To set the
placeholder to list all parts, e.g.: `<first>[:<second>]`