### PR TITLE
Allow empty command

### DIFF
--- a/app.go
+++ b/app.go
@@ -229,7 +229,7 @@ func (a *Application) Parse(args []string) (command string, err error) {
 
 		command, err = a.execute(context, selected)
 		if err == ErrCommandNotSpecified {
-			a.writeUsage(context, nil)
+			return "", nil
 		}
 	}
 	return command, err


### PR DESCRIPTION
When using one or more commands with `myApp.Command(...)`, the user _must_ specify one of those commands. Maybe it's useful to also _not_ specify a command and run into a REPL, default routine or something else.

This is just something I ran into several times, maybe it's useful for you, too.

### Example
Python does something like that: `python` starts a REPL but I can also say `python -c "..."` to directly execute code.