### PR TITLE
Add setter for help message

### DIFF
--- a/args.go
+++ b/args.go
@@ -188,6 +188,12 @@ func (a *ArgClause) HintOptions(options ...string) *ArgClause {
 	return a
 }
 
+// Help sets the help message.
+func (a *ArgClause) Help(help string) *ArgClause {
+	a.help = help
+	return a
+}
+
 func (a *ArgClause) init() error {
 	if a.required && len(a.defaultValues) > 0 {
 		return fmt.Errorf("required argument '%s' with unusable default value", a.name)

--- a/cmd.go
+++ b/cmd.go
@@ -283,6 +283,12 @@ func (c *CmdClause) PreAction(action Action) *CmdClause {
 	return c
 }
 
+// Help sets the help message.
+func (c *CmdClause) Help(help string) *CmdClause {
+	c.help = help
+	return c
+}
+
 func (c *CmdClause) init() error {
 	if err := c.flagGroup.init(c.app.defaultEnvarPrefix()); err != nil {
 		return err

--- a/flags.go
+++ b/flags.go
@@ -318,6 +318,12 @@ func (f *FlagClause) Short(name rune) *FlagClause {
 	return f
 }
 
+// Help sets the help message.
+func (f *FlagClause) Help(help string) *FlagClause {
+	f.help = help
+	return f
+}
+
 // Bool makes this flag a boolean flag.
 func (f *FlagClause) Bool() (target *bool) {
 	target = new(bool)


### PR DESCRIPTION
Maybe someone wants to change the default help messages (e.g. of the `--version` flag), than this adds the opportunity to do so.