### PR TITLE
Remove newline before #compdef

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -245,8 +245,7 @@ complete -F _{{.App.Name}}_bash_autocomplete -o default {{.App.Name}}
 
 `
 
-var ZshCompletionTemplate = `
-#compdef {{.App.Name}}
+var ZshCompletionTemplate = `#compdef {{.App.Name}}
 
 _{{.App.Name}}() {
     local matches=($(${words[1]} --completion-bash "${(@)words[1,$CURRENT]}"))


### PR DESCRIPTION
zsh's compinit only considers files where the absolute first line starts with #compdef or #autoload [1]. Kingpin was generating completion files with a leading newline, causing this logic to skip the file.

[1]: https://github.com/zsh-users/zsh/blob/27a64a16fb5407c64ff190f2af5182797ac048a8/Completion/compinit#L503-L504