### PR TITLE
Support encoding.Text(Unm|M)arshaler

### DIFF
--- a/parsers.go
+++ b/parsers.go
@@ -18,6 +18,10 @@ type parserMixin struct {
 	required bool
 }
 
+func (p *parserMixin) SetText(text Text) {
+	p.value = &wrapText{text}
+}
+
 func (p *parserMixin) SetValue(value Value) {
 	p.value = value
 }

--- a/values.go
+++ b/values.go
@@ -3,6 +3,7 @@ package kingpin
 //go:generate go run ./cmd/genvalues/main.go
 
 import (
+	"encoding"
 	"fmt"
 	"net"
 	"net/url"
@@ -54,6 +55,31 @@ type remainderArg interface {
 // Optional interface for flags that can be repeated.
 type repeatableFlag interface {
 	IsCumulative() bool
+}
+
+// Text is the interface to the dynamic value stored in a flag.
+// (The default value is represented as a string.)
+//
+// If a Text has an IsBoolFlag() bool method returning true, the command-line
+// parser makes --name equivalent to -name=true rather than using the next
+// command-line argument, and adds a --no-name counterpart for negating the
+// flag.
+type Text interface {
+	encoding.TextMarshaler
+	encoding.TextUnmarshaler
+}
+
+type wrapText struct {
+	text Text
+}
+
+func (w wrapText) String() string {
+	buf, _ := w.text.MarshalText()
+	return string(buf)
+}
+
+func (w *wrapText) Set(s string) error {
+	return w.text.UnmarshalText([]byte(s))
 }
 
 type accumulator struct {

--- a/values.go
+++ b/values.go
@@ -59,11 +59,6 @@ type repeatableFlag interface {
 
 // Text is the interface to the dynamic value stored in a flag.
 // (The default value is represented as a string.)
-//
-// If a Text has an IsBoolFlag() bool method returning true, the command-line
-// parser makes --name equivalent to -name=true rather than using the next
-// command-line argument, and adds a --no-name counterpart for negating the
-// flag.
 type Text interface {
 	encoding.TextMarshaler
 	encoding.TextUnmarshaler

--- a/values.go
+++ b/values.go
@@ -42,20 +42,17 @@ type Getter interface {
 // Optional interface to indicate boolean flags that don't accept a value, and
 // implicitly have a --no-<x> negation counterpart.
 type boolFlag interface {
-	Value
 	IsBoolFlag() bool
 }
 
 // Optional interface for arguments that cumulatively consume all remaining
 // input.
 type remainderArg interface {
-	Value
 	IsCumulative() bool
 }
 
 // Optional interface for flags that can be repeated.
 type repeatableFlag interface {
-	Value
 	IsCumulative() bool
 }
 


### PR DESCRIPTION
I'm fed up with implementing "MarhsalXXX", "Stringer", etc, etc...
kingpin requires "Value" interface to parse string
even though there's cool interface "encoding.TextUnmarshaler".