### PR TITLE
Fix autocompletion of args that consume remainder

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -36,8 +36,10 @@ ElementLoop:
 				if len(validOptions) == 0 {
 					// If there are no options for this argument,
 					// mark is as allSatisfied as we can't suggest anything
-					argsSatisfied++
-					allSatisfied = true
+					if !clause.consumesRemainder() {
+						argsSatisfied++
+						allSatisfied = true
+					}
 					continue ElementLoop
 				}
 
@@ -45,7 +47,9 @@ ElementLoop:
 					if opt == *el.Value {
 						// We have an exact match
 						// We don't need to suggest any option
-						argsSatisfied++
+						if !clause.consumesRemainder() {
+							argsSatisfied++
+						}
 						continue ElementLoop
 					}
 					if strings.HasPrefix(opt, *el.Value) {
@@ -54,8 +58,10 @@ ElementLoop:
 					}
 				}
 				// Avoid further completion as we have done everything we could
-				argsSatisfied++
-				allSatisfied = true
+				if !clause.consumesRemainder() {
+					argsSatisfied++
+					allSatisfied = true
+				}
 			}
 		case *CmdClause:
 			options = append(options, clause.completionAlts...)


### PR DESCRIPTION
The Go runtime would panic at the following line because of an out-of-bounds slice access if autocompletion was requested for a clause that consumed the remainder of a command:

https://github.com/alecthomas/kingpin/blob/cf44c60659e38b5559aa885c13ad76c9bd6e8d50/cmd.go#L35

 By specifically checking for these kinds of clauses, the problem should be mitigated.

**Example**
```golang
package main

import "github.com/alecthomas/kingpin"

func main() {
  var strings []string
  kingpin.Arg("test", "").StringsVar(&strings)
  kingpin.Parse()
}
```
```
$ go run main.go --completion-bash 1 2  
panic: runtime error: index out of range [1] with length 1
```