### PR TITLE
Honour -- delimiter in autocompletion

### DIFF
--- a/app.go
+++ b/app.go
@@ -633,7 +633,7 @@ func (a *Application) completionOptions(context *ParseContext) []string {
 		target = context.SelectedCommand.cmdMixin
 	}
 
-	if (currArg != "" && strings.HasPrefix(currArg, "--")) || strings.HasPrefix(prevArg, "--") {
+	if !context.argsOnly && ((currArg != "" && strings.HasPrefix(currArg, "--")) || strings.HasPrefix(prevArg, "--")) {
 		// Perform completion for A flag. The last/current argument started with "-"
 		var (
 			flagName  string // The name of a flag if given (could be half complete)


### PR DESCRIPTION
If a `--` argument is passed, from then on only arguments should be parsed. This is already handled correctly in most places, but autocompleting did not honour this yet.

**Example**
```golang
package main

import "github.com/alecthomas/kingpin"

func main(){
   kingpin.Arg("arg1", "").String()
   kingpin.Flag("flag1", "").String()
   kingpin.Flag("flag2", "").String()
   kingpin.Parse()
}
```

If this following command is executed:
```
go run main.go --completion-bash an-argument --flag1 --  --
```
We expect not to get a suggestion for any of the flags of the command because the `--` argument signals that all arguments were provided. However, on the current `master`, the result is:
```sh
$ go run main.go --completion-bash an-argument --flag1 --  --
--help
--flag1
--flag2
```