### PR TITLE
Honour -- delimiter in autocompletion

### DIFF
--- a/app.go
+++ b/app.go
@@ -635,7 +635,7 @@ func (a *Application) completionOptions(context *ParseContext) []string {
 
 	if (currArg != "" && strings.HasPrefix(currArg, "--")) || strings.HasPrefix(prevArg, "--") {
 		if context.argsOnly {
-			return []string{}
+			return nil
 		}
 
 		// Perform completion for A flag. The last/current argument started with "-"

--- a/app.go
+++ b/app.go
@@ -634,6 +634,10 @@ func (a *Application) completionOptions(context *ParseContext) []string {
 	}
 
 	if (currArg != "" && strings.HasPrefix(currArg, "--")) || strings.HasPrefix(prevArg, "--") {
+		if context.argsOnly {
+			return []string{}
+		}
+
 		// Perform completion for A flag. The last/current argument started with "-"
 		var (
 			flagName  string // The name of a flag if given (could be half complete)

--- a/app_test.go
+++ b/app_test.go
@@ -390,6 +390,16 @@ func TestBashCompletionOptions(t *testing.T) {
 			Args:            "--completion-bash three arg1 arg2 arg3 arg4",
 			ExpectedOptions: []string(nil),
 		},
+		{
+			// After a -- argument, no more flags should be suggested
+			Args:            "--completion-bash three --flag-0 -- --",
+			ExpectedOptions: []string(nil),
+		},
+		{
+			// After a -- argument, argument options should still be suggested
+			Args:            "--completion-bash three -- arg1 ",
+			ExpectedOptions: []string{"arg-2-opt-1", "arg-2-opt-2"},
+		},
 	}
 
 	for _, c := range cases {

--- a/parser.go
+++ b/parser.go
@@ -166,6 +166,10 @@ func (p *ParseContext) Next() *Token {
 		return &Token{Index: p.argi, Type: TokenEOL}
 	}
 
+	if p.argi > 0 && p.rawArgs[p.argi-1] == "--" {
+		// If the previous argument was a --, from now on only arguments are parsed.
+		p.argsOnly = true
+	}
 	arg := p.args[0]
 	p.next()
 
@@ -173,9 +177,7 @@ func (p *ParseContext) Next() *Token {
 		return &Token{p.argi, TokenArg, arg}
 	}
 
-	// All remaining args are passed directly.
 	if arg == "--" {
-		p.argsOnly = true
 		return p.Next()
 	}
 

--- a/parser.go
+++ b/parser.go
@@ -166,7 +166,7 @@ func (p *ParseContext) Next() *Token {
 		return &Token{Index: p.argi, Type: TokenEOL}
 	}
 
-	if p.argi > 0 && p.rawArgs[p.argi-1] == "--" {
+	if p.argi > 0 && p.argi <= len(p.rawArgs) && p.rawArgs[p.argi-1] == "--" {
 		// If the previous argument was a --, from now on only arguments are parsed.
 		p.argsOnly = true
 	}


### PR DESCRIPTION
If a `--` argument is passed, from then on only arguments should be parsed. This is already handled correctly in most places, but autocompleting did not honour this yet.

**Example**
```golang
package main

import "github.com/alecthomas/kingpin"

func main(){
   kingpin.Arg("arg1", "").String()
   kingpin.Flag("flag1", "").String()
   kingpin.Flag("flag2", "").String()
   kingpin.Parse()
}
```

If this following command is executed:
```
go run main.go --completion-bash an-argument --flag1 --  --
```
We expect not to get a suggestion for any of the flags of the command because the `--` argument signals that all arguments were provided. However, on the current `master`, the result is:
```sh
$ go run main.go --completion-bash an-argument --flag1 --  --
--help
--flag1
--flag2
```

If there is a more elegant solution to achieve this (without a big refactor), I'm happy to hear it. 