### PR TITLE
Show boolean value type default in flag formatting.

### DIFF
--- a/usage.go
+++ b/usage.go
@@ -84,9 +84,7 @@ func formatFlag(haveShort bool, flag *FlagModel) string {
 			flagString += fmt.Sprintf("--%s", flag.Name)
 		}
 	}
-	if !flag.IsBoolFlag() {
-		flagString += fmt.Sprintf("=%s", flag.FormatPlaceHolder())
-	}
+	flagString += fmt.Sprintf("=%s", flag.FormatPlaceHolder())
 	if v, ok := flag.Value.(repeatableFlag); ok && v.IsCumulative() {
 		flagString += " ..."
 	}

--- a/usage_test.go
+++ b/usage_test.go
@@ -92,6 +92,18 @@ func TestCmdClause_HelpLong(t *testing.T) {
 	assert.Equal(t, "long help text", usage)
 }
 
+func TestFlagModel_Default(t *testing.T) {
+	var defaultValue bool
+	value := newBoolValue(&defaultValue)
+	f := FlagModel{
+		Default: []string{"false"},
+		Name:    "a-boolean-flag",
+		Help:    "help text",
+		Value:   value,
+	}
+	assert.Equal(t, "--a-boolean-flag=false", formatFlag(false, &f))
+}
+
 func TestArgEnvVar(t *testing.T) {
 	var buf bytes.Buffer
 


### PR DESCRIPTION
Fixes: #243

Unsure if contradicts with kingpins design to have the implicit `--no-name` flags.

cc: @autarch @alecthomas 

Signed-off-by: Hrishikesh Barman <hrishikeshbman@gmail.com>