### PR TITLE
Added possibility to have modular extending of the CLI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,5 @@ sudo: false
 language: go
 install: go get -t -v ./...
 go:
-    - 1.2.x
-    - 1.3.x
-    - 1.4.x
-    - 1.5.x
-    - 1.6.x
-    - 1.7.x
-    - 1.8.x
-    - 1.9.x
-    - 1.10.x
-    - 1.11.x
+    - 1.13.x
+    - 1.14.x

--- a/_examples/components_commands/info.go
+++ b/_examples/components_commands/info.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+type Info struct {
+	SomeFlag string
+}
+
+func (i *Info) RegisterCommands(c kingpin.Cmd) {
+	cmd := c.Command("info", "information about me").
+		EnvarNamePrefix("INFO_").
+		Action(i.action)
+
+	cmd.Flag("some-flag", "just some flag").
+		Default("foobar").
+		Envar("SOME_FLAG").
+		StringVar(&i.SomeFlag)
+}
+
+func (i *Info) action(*kingpin.ParseContext) error {
+	fmt.Println("This is me.", i.SomeFlag)
+	return nil
+}

--- a/_examples/components_commands/main.go
+++ b/_examples/components_commands/main.go
@@ -1,0 +1,8 @@
+package main
+
+import "gopkg.in/alecthomas/kingpin.v2"
+
+func main() {
+	kingpin.CmdsOf(&Info{}, &Show{})
+	kingpin.Parse()
+}

--- a/_examples/components_commands/show.go
+++ b/_examples/components_commands/show.go
@@ -1,0 +1,14 @@
+package main
+
+import "gopkg.in/alecthomas/kingpin.v2"
+
+type Show struct {
+	ShowFiles
+	ShowVariables
+}
+
+func (s *Show) RegisterCommands(c kingpin.Cmd) {
+	c.Command("show", "show some stuff").
+		EnvarNamePrefix("SHOW_").
+		CmdsOf(&s.ShowFiles, &s.ShowVariables)
+}

--- a/_examples/components_commands/show_files.go
+++ b/_examples/components_commands/show_files.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"gopkg.in/alecthomas/kingpin.v2"
+	"io/ioutil"
+)
+
+type ShowFiles struct {
+	Root string
+}
+
+func (s *ShowFiles) RegisterCommands(c kingpin.Cmd) {
+	cmd := c.Command("files", "show some files").
+		EnvarNamePrefix("FILES_").
+		Action(s.action)
+
+	cmd.Flag("root", "where to start to show files of").
+		Default(".").
+		Envar("ROOT").
+		ExistingDirVar(&s.Root)
+}
+
+func (s *ShowFiles) action(*kingpin.ParseContext) error {
+	files, err := ioutil.ReadDir(s.Root)
+	if err != nil {
+		return err
+	}
+
+	for _, f := range files {
+		fmt.Println(f.Name())
+	}
+	return nil
+}

--- a/_examples/components_commands/show_variables.go
+++ b/_examples/components_commands/show_variables.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"gopkg.in/alecthomas/kingpin.v2"
+	"os"
+	"regexp"
+	"strings"
+)
+
+type ShowVariables struct {
+	Filter *regexp.Regexp
+}
+
+func (s *ShowVariables) RegisterCommands(c kingpin.Cmd) {
+	cmd := c.Command("variables", "show some environment variables").
+		EnvarNamePrefix("VARIABLES_").
+		Action(s.action)
+
+	cmd.Flag("filter", "name which should match this pattern").
+		Default(".*").
+		Envar("FILTER").
+		RegexpVar(&s.Filter)
+}
+
+func (s *ShowVariables) action(*kingpin.ParseContext) error {
+	for _, keyToValue := range os.Environ() {
+		keyAndValue := strings.SplitN(keyToValue, "=", 2)
+		if s.Filter.MatchString(keyAndValue[0]) {
+			fmt.Println(keyToValue)
+		}
+	}
+	return nil
+}

--- a/_examples/components_flags/main.go
+++ b/_examples/components_flags/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+func main() {
+	o := Output{}
+	kingpin.FlagsOf(&o)
+	kingpin.Parse()
+
+	minifiedPrefix := ""
+	if o.Encoding.Minify {
+		minifiedPrefix = "minified "
+	}
+	fmt.Printf("Would send data encoded as %s%s to %s:%d.",
+		minifiedPrefix, o.Encoding.Format, o.Connection.Host, o.Connection.Port)
+}

--- a/_examples/components_flags/output.go
+++ b/_examples/components_flags/output.go
@@ -1,0 +1,14 @@
+package main
+
+import "gopkg.in/alecthomas/kingpin.v2"
+
+type Output struct {
+	Encoding   OutputEncoding
+	Connection OutputConnection
+}
+
+func (s *Output) RegisterFlags(fg kingpin.FlagGroup) {
+	fg.FlagGroup("output.").
+		EnvarNamePrefix("OUTPUT_").
+		FlagsOf(&s.Encoding, &s.Connection)
+}

--- a/_examples/components_flags/output_connection.go
+++ b/_examples/components_flags/output_connection.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+type OutputConnection struct {
+	Host string
+	Port uint16
+}
+
+func (o *OutputConnection) RegisterFlags(fg kingpin.FlagGroup) {
+	g := fg.FlagGroup("connection.").
+		EnvarNamePrefix("CONNECTION_")
+
+	g.Flag("host", "Host to send the output data to.").
+		Required().
+		Envar("HOST").
+		StringVar(&o.Host)
+	g.Flag("port", "Port of the host to send the output data to.").
+		Default("12345").
+		Envar("PORT").
+		Uint16Var(&o.Port)
+}

--- a/_examples/components_flags/output_encoding.go
+++ b/_examples/components_flags/output_encoding.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+type OutputEncoding struct {
+	Format string
+	Minify bool
+}
+
+func (o *OutputEncoding) RegisterFlags(fg kingpin.FlagGroup) {
+	g := fg.FlagGroup("encoding.").
+		EnvarNamePrefix("ENCODING_")
+
+	g.Flag("format", "Format to encode the result with.").
+		Default("json").
+		Envar("FORMAT").
+		EnumVar(&o.Format, "json", "yaml")
+	g.Flag("minify", "If set the output format will be minified, if possible.").
+		Envar("MINIFY").
+		BoolVar(&o.Minify)
+}

--- a/actions.go
+++ b/actions.go
@@ -5,6 +5,19 @@ package kingpin
 // actions.
 type Action func(*ParseContext) error
 
+// ActionGroup provides access to define actions and pre-actions.
+type ActionGroup interface {
+	// AddAction callback to call when all values are populated and parsing is
+	// complete, but before any command, flag or argument actions.
+	//
+	// All Action() callbacks are called in the order they are encountered on the
+	// command line.
+	AddAction(action Action)
+
+	// AddPreAction called after parsing completes but before validation and execution.
+	AddPreAction(action Action)
+}
+
 type actionMixin struct {
 	actions    []Action
 	preActions []Action

--- a/app_test.go
+++ b/app_test.go
@@ -223,9 +223,97 @@ func TestDefaultEnvars(t *testing.T) {
 	f2.Bool()
 	_, err := a.Parse([]string{})
 	assert.NoError(t, err)
-	assert.Equal(t, "SOME_APP_SOME_FLAG", f0.envar)
-	assert.Equal(t, "", f1.envar)
-	assert.Equal(t, "SOME_APP_A_1_FLAG", f2.envar)
+	assert.Equal(t, "SOME_APP_SOME_FLAG", f0.getEnvar())
+	assert.Equal(t, "", f1.getEnvar())
+	assert.Equal(t, "SOME_APP_A_1_FLAG", f2.getEnvar())
+}
+
+func TestEnvarNamePrefixOnCommands(t *testing.T) {
+	app := New("some-app", "").Terminate(nil).EnvarNamePrefix("FOO_")
+
+	c1 := app.Command("c1", "").EnvarNamePrefix("C1_")
+	f11 := c1.Flag("f11", "").Envar("F11")
+	f12 := c1.Flag("f12", "")
+	c11 := c1.Command("c11", "").EnvarNamePrefix("C11_")
+	f111 := c11.Flag("f111", "").Envar("F111")
+	f112 := c11.Flag("f112", "")
+	c12 := c1.Command("c12", "")
+	f121 := c12.Flag("f121", "").Envar("F121")
+	f122 := c12.Flag("f122", "")
+
+	c2 := app.Command("c2", "")
+	f21 := c2.Flag("f21", "").Envar("F21")
+	f22 := c2.Flag("f22", "")
+	c21 := c2.Command("c21", "").EnvarNamePrefix("C21_")
+	f211 := c21.Flag("f211", "").Envar("F211")
+	f212 := c21.Flag("f212", "")
+	c22 := c2.Command("c22", "")
+	f221 := c22.Flag("f221", "").Envar("F221")
+	f222 := c22.Flag("f222", "")
+
+	for _, f := range []*FlagClause{f11, f12, f111, f112, f121, f122, f21, f22, f211, f212, f221, f222} {
+		f.Bool()
+	}
+
+	_, err := app.Parse([]string{"c1", "c11"})
+	assert.NoError(t, err)
+	assert.Equal(t, "FOO_C1_F11", f11.getEnvar())
+	assert.Equal(t, "", f12.getEnvar())
+	assert.Equal(t, "FOO_C1_C11_F111", f111.getEnvar())
+	assert.Equal(t, "", f112.getEnvar())
+	assert.Equal(t, "FOO_C1_F121", f121.getEnvar())
+	assert.Equal(t, "", f122.getEnvar())
+
+	assert.Equal(t, "FOO_F21", f21.getEnvar())
+	assert.Equal(t, "", f22.getEnvar())
+	assert.Equal(t, "FOO_C21_F211", f211.getEnvar())
+	assert.Equal(t, "", f212.getEnvar())
+	assert.Equal(t, "FOO_F221", f221.getEnvar())
+	assert.Equal(t, "", f222.getEnvar())
+}
+
+func TestEnvarNamePrefixOnFlagGroups(t *testing.T) {
+	app := New("some-app", "").Terminate(nil).EnvarNamePrefix("FOO_")
+
+	g1 := app.FlagGroup("g1").EnvarNamePrefix("G1_")
+	f11 := g1.Flag("f11", "").Envar("F11")
+	f12 := g1.Flag("f12", "")
+	g11 := g1.FlagGroup("g11").EnvarNamePrefix("G11_")
+	f111 := g11.Flag("f111", "").Envar("F111")
+	f112 := g11.Flag("f112", "")
+	g12 := g1.FlagGroup("g12")
+	f121 := g12.Flag("f121", "").Envar("F121")
+	f122 := g12.Flag("f122", "")
+
+	g2 := app.FlagGroup("g2")
+	f21 := g2.Flag("f21", "").Envar("F21")
+	f22 := g2.Flag("f22", "")
+	g21 := g2.FlagGroup("g21").EnvarNamePrefix("G21_")
+	f211 := g21.Flag("f211", "").Envar("F211")
+	f212 := g21.Flag("f212", "")
+	g22 := g2.FlagGroup("g22")
+	f221 := g22.Flag("f221", "").Envar("F221")
+	f222 := g22.Flag("f222", "")
+
+	for _, f := range []*FlagClause{f11, f12, f111, f112, f121, f122, f21, f22, f211, f212, f221, f222} {
+		f.Bool()
+	}
+
+	_, err := app.Parse([]string{})
+	assert.NoError(t, err)
+	assert.Equal(t, "FOO_G1_F11", f11.getEnvar())
+	assert.Equal(t, "", f12.getEnvar())
+	assert.Equal(t, "FOO_G1_G11_F111", f111.getEnvar())
+	assert.Equal(t, "", f112.getEnvar())
+	assert.Equal(t, "FOO_G1_F121", f121.getEnvar())
+	assert.Equal(t, "", f122.getEnvar())
+
+	assert.Equal(t, "FOO_F21", f21.getEnvar())
+	assert.Equal(t, "", f22.getEnvar())
+	assert.Equal(t, "FOO_G21_F211", f211.getEnvar())
+	assert.Equal(t, "", f212.getEnvar())
+	assert.Equal(t, "FOO_F221", f221.getEnvar())
+	assert.Equal(t, "", f222.getEnvar())
 }
 
 func TestBashCompletionOptionsWithEmptyApp(t *testing.T) {
@@ -433,4 +521,116 @@ func TestCmdValidation(t *testing.T) {
 
 	_, err = c.Parse([]string{"cmd", "--a", "A"})
 	assert.NoError(t, err)
+}
+
+func TestSubFlagGroup(t *testing.T) {
+	app := newTestApp()
+	f1 := app.Flag("f1", "")
+
+	g1 := app.FlagGroup("g1.")
+	f11 := g1.Flag("f11", "")
+
+	g11 := g1.FlagGroup("g11.")
+	f111 := g11.Flag("f111", "").Required()
+
+	for _, f := range []*FlagClause{f1, f11, f111} {
+		f.String()
+	}
+
+	context, err := app.ParseContext([]string{})
+	assert.NoError(t, err)
+
+	assert.Equal(t, f1, context.flags.long["f1"])
+	assert.Equal(t, f11, context.flags.long["g1.f11"])
+	assert.Equal(t, f111, context.flags.long["g1.g11.f111"])
+
+	_, err = app.Parse([]string{})
+
+	assert.EqualError(t, err, "required flag --g1.g11.f111 not provided")
+}
+
+func TestFlagsOf(t *testing.T) {
+	app := newTestApp().FlagsOf(FlagRegistrarFunc(func(fg FlagGroup) {
+		fg.Flag("app1", "").Bool()
+		fg.Flag("app2", "").Bool()
+	}), FlagRegistrarFunc(func(fg FlagGroup) {
+		fg.Flag("app3", "").Bool()
+		fg.Flag("app4", "").Bool()
+	}))
+
+	cmd1 := app.Command("cmd1", "").FlagsOf(FlagRegistrarFunc(func(fg FlagGroup) {
+		fg.Flag("cmd11", "").Bool()
+		fg.Flag("cmd12", "").Bool()
+	}), FlagRegistrarFunc(func(fg FlagGroup) {
+		fg.Flag("cmd13", "").Bool()
+		fg.Flag("cmd14", "").Bool()
+	}))
+
+	cmd11 := cmd1.Command("cmd11", "").FlagsOf(FlagRegistrarFunc(func(fg FlagGroup) {
+		fg.Flag("cmd111", "").Bool()
+		fg.Flag("cmd112", "").Bool()
+	}), FlagRegistrarFunc(func(fg FlagGroup) {
+		fg.Flag("cmd113", "").Bool()
+		fg.Flag("cmd114", "").Bool()
+	}))
+
+	_, err := app.Parse([]string{"cmd1", "cmd11"})
+	assert.NoError(t, err)
+	assert.IsType(t, &boolValue{}, app.GetFlag("app1").value)
+	assert.IsType(t, &boolValue{}, app.GetFlag("app2").value)
+	assert.IsType(t, &boolValue{}, app.GetFlag("app3").value)
+	assert.IsType(t, &boolValue{}, app.GetFlag("app4").value)
+
+	assert.IsType(t, &boolValue{}, cmd1.GetFlag("cmd11").value)
+	assert.IsType(t, &boolValue{}, cmd1.GetFlag("cmd12").value)
+	assert.IsType(t, &boolValue{}, cmd1.GetFlag("cmd13").value)
+	assert.IsType(t, &boolValue{}, cmd1.GetFlag("cmd14").value)
+
+	assert.IsType(t, &boolValue{}, cmd11.GetFlag("cmd111").value)
+	assert.IsType(t, &boolValue{}, cmd11.GetFlag("cmd112").value)
+	assert.IsType(t, &boolValue{}, cmd11.GetFlag("cmd113").value)
+	assert.IsType(t, &boolValue{}, cmd11.GetFlag("cmd114").value)
+}
+
+func TestCmdsOf(t *testing.T) {
+	app := newTestApp().CmdsOf(CmdRegistrarFunc(func(c Cmd) {
+		c.Command("app-1", "h app-1")
+		c.Command("app-2", "h app-2")
+	}), CmdRegistrarFunc(func(c Cmd) {
+		c.Command("app-3", "h app-3")
+		c.Command("app-4", "h app-4")
+	}))
+
+	cmd1 := app.Command("cmd1", "").CmdsOf(CmdRegistrarFunc(func(c Cmd) {
+		c.Command("cmd1-1", "h cmd1-1")
+		c.Command("cmd1-2", "h cmd1-2")
+	}), CmdRegistrarFunc(func(c Cmd) {
+		c.Command("cmd1-3", "h cmd1-3")
+		c.Command("cmd1-4", "h cmd1-4")
+	}))
+
+	cmd11 := cmd1.Command("cmd11", "").CmdsOf(CmdRegistrarFunc(func(c Cmd) {
+		c.Command("cmd11-1", "h cmd11-1")
+		c.Command("cmd11-2", "h cmd11-2")
+	}), CmdRegistrarFunc(func(c Cmd) {
+		c.Command("cmd11-3", "h cmd11-3")
+		c.Command("cmd11-4", "h cmd11-4")
+	}))
+
+	_, err := app.Parse([]string{"cmd1", "cmd11", "cmd11-1"})
+	assert.NoError(t, err)
+	assert.Equal(t, "h app-1", app.GetCommand("app-1").help)
+	assert.Equal(t, "h app-2", app.GetCommand("app-2").help)
+	assert.Equal(t, "h app-3", app.GetCommand("app-3").help)
+	assert.Equal(t, "h app-4", app.GetCommand("app-4").help)
+
+	assert.Equal(t, "h cmd1-1", cmd1.GetCommand("cmd1-1").help)
+	assert.Equal(t, "h cmd1-2", cmd1.GetCommand("cmd1-2").help)
+	assert.Equal(t, "h cmd1-3", cmd1.GetCommand("cmd1-3").help)
+	assert.Equal(t, "h cmd1-4", cmd1.GetCommand("cmd1-4").help)
+
+	assert.Equal(t, "h cmd11-1", cmd11.GetCommand("cmd11-1").help)
+	assert.Equal(t, "h cmd11-2", cmd11.GetCommand("cmd11-2").help)
+	assert.Equal(t, "h cmd11-3", cmd11.GetCommand("cmd11-3").help)
+	assert.Equal(t, "h cmd11-4", cmd11.GetCommand("cmd11-4").help)
 }

--- a/args_test.go
+++ b/args_test.go
@@ -19,8 +19,8 @@ func TestArgRemainder(t *testing.T) {
 
 func TestArgRemainderErrorsWhenNotLast(t *testing.T) {
 	a := newArgGroup()
-	a.Arg("test", "").Strings()
-	a.Arg("test2", "").String()
+	a.newArg("test", "", nil).Strings()
+	a.newArg("test2", "", nil).String()
 	assert.Error(t, a.init())
 }
 

--- a/envar.go
+++ b/envar.go
@@ -12,19 +12,32 @@ var (
 )
 
 type envarMixin struct {
-	envar   string
-	noEnvar bool
+	nameResolver envarNameResolver
+	envar        string
+	noEnvar      bool
 }
+
+type envarNameResolver func(string) string
 
 func (e *envarMixin) HasEnvarValue() bool {
 	return e.GetEnvarValue() != ""
 }
 
 func (e *envarMixin) GetEnvarValue() string {
+	if n := e.getEnvar(); n != "" {
+		return os.Getenv(n)
+	}
+	return ""
+}
+
+func (e *envarMixin) getEnvar() string {
 	if e.noEnvar || e.envar == "" {
 		return ""
 	}
-	return os.Getenv(e.envar)
+	if r := e.nameResolver; r != nil {
+		return r(e.envar)
+	}
+	return e.envar
 }
 
 func (e *envarMixin) GetSplitEnvarValue() []string {

--- a/flags.go
+++ b/flags.go
@@ -5,16 +5,43 @@ import (
 	"strings"
 )
 
+// FlagGroup provides access to defining and retrieving flags
+type FlagGroup interface {
+	// GetFlag gets a flag definition.
+	//
+	// This allows existing flags to be modified after definition but before parsing. Useful for
+	// modular applications.
+	GetFlag(name string) *FlagClause
+
+	// Flag defines a new flag with the given long name and help.
+	Flag(name, help string) *FlagClause
+
+	// GetFlagGroup returns a child by the given name of this FlagGroup
+	GetFlagGroup(prefix string) *SubFlagGroup
+
+	// FlagGroup create a new sub group at this FlagGroup with the given name.
+	//
+	// This allows grouping flags and prevents duplication of namings.
+	FlagGroup(prefix string) *SubFlagGroup
+
+	// RegisterFlagsOf will execute a registrar for flags for this FlagGroup.
+	RegisterFlagsOf(registrars ...FlagRegistrar)
+}
+
 type flagGroup struct {
 	short     map[string]*FlagClause
 	long      map[string]*FlagClause
 	flagOrder []*FlagClause
+
+	subGroups       map[string]*SubFlagGroup
+	envarNamePrefix string
 }
 
 func newFlagGroup() *flagGroup {
 	return &flagGroup{
-		short: map[string]*FlagClause{},
-		long:  map[string]*FlagClause{},
+		short:     map[string]*FlagClause{},
+		long:      map[string]*FlagClause{},
+		subGroups: map[string]*SubFlagGroup{},
 	}
 }
 
@@ -26,18 +53,41 @@ func (f *flagGroup) GetFlag(name string) *FlagClause {
 	return f.long[name]
 }
 
-// Flag defines a new flag with the given long name and help.
-func (f *flagGroup) Flag(name, help string) *FlagClause {
-	flag := newFlag(name, help)
+func (f *flagGroup) newFlag(name, help string, holder FlagGroup, envarNameResolver envarNameResolver) *FlagClause {
+	flag := newFlag(name, help, holder, envarNameResolver)
 	f.long[name] = flag
 	f.flagOrder = append(f.flagOrder, flag)
 	return flag
+}
+
+// GetFlagGroup returns a child by the given name of this FlagGroup
+func (f *flagGroup) GetFlagGroup(prefix string) *SubFlagGroup {
+	return f.subGroups[prefix]
+}
+
+// FlagGroup create a new sub group at this FlagGroup with the given name.
+//
+// This allows grouping flags and prevents duplication of namings.
+func (f *flagGroup) newFlagGroup(prefix string, holder FlagGroup, parentEnvarPrefixProvider envarPrefixProvider) *SubFlagGroup {
+	fg := newFlagGroup()
+	s := &SubFlagGroup{
+		flagGroup:                 *fg,
+		parentEnvarPrefixProvider: parentEnvarPrefixProvider,
+		holder:                    holder,
+		prefix:                    prefix,
+	}
+	f.subGroups[prefix] = s
+	return s
 }
 
 func (f *flagGroup) init(defaultEnvarPrefix string) error {
 	if err := f.checkDuplicates(); err != nil {
 		return err
 	}
+	return f.initRecursively(defaultEnvarPrefix)
+}
+
+func (f *flagGroup) initRecursively(defaultEnvarPrefix string) error {
 	for _, flag := range f.long {
 		if defaultEnvarPrefix != "" && !flag.noEnvar && flag.envar == "" {
 			flag.envar = envarTransform(defaultEnvarPrefix + "_" + flag.name)
@@ -49,12 +99,25 @@ func (f *flagGroup) init(defaultEnvarPrefix string) error {
 			f.short[string(flag.shorthand)] = flag
 		}
 	}
+	for name, subGroup := range f.subGroups {
+		subPrefix := ""
+		if defaultEnvarPrefix != "" {
+			subPrefix = defaultEnvarPrefix + "_" + name
+		}
+		if err := subGroup.initRecursively(subPrefix); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
 func (f *flagGroup) checkDuplicates() error {
 	seenShort := map[rune]bool{}
 	seenLong := map[string]bool{}
+	return f.checkDuplicatesRecursively("", seenShort, seenLong)
+}
+
+func (f *flagGroup) checkDuplicatesRecursively(prefix string, seenShort map[rune]bool, seenLong map[string]bool) error {
 	for _, flag := range f.flagOrder {
 		if flag.shorthand != 0 {
 			if _, ok := seenShort[flag.shorthand]; ok {
@@ -62,12 +125,43 @@ func (f *flagGroup) checkDuplicates() error {
 			}
 			seenShort[flag.shorthand] = true
 		}
-		if _, ok := seenLong[flag.name]; ok {
-			return fmt.Errorf("duplicate long flag --%s", flag.name)
+		if _, ok := seenLong[prefix+flag.name]; ok {
+			return fmt.Errorf("duplicate long flag --%s", prefix+flag.name)
 		}
-		seenLong[flag.name] = true
+		seenLong[prefix+flag.name] = true
+	}
+	for name, subGroup := range f.subGroups {
+		if err := subGroup.checkDuplicatesRecursively(prefix+name, seenShort, seenLong); err != nil {
+			return err
+		}
 	}
 	return nil
+}
+
+func (f *flagGroup) getShort(name string) (*FlagClause, bool) {
+	if v, ok := f.short[name]; ok {
+		return v, true
+	}
+	for _, subGroup := range f.subGroups {
+		if v, ok := subGroup.getShort(name); ok {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+func (f *flagGroup) getLong(name string) (*FlagClause, bool) {
+	if v, ok := f.long[name]; ok {
+		return v, true
+	}
+	for subGroupName, subGroup := range f.subGroups {
+		if strings.HasPrefix(name, subGroupName) {
+			if v, ok := subGroup.getLong(name[len(subGroupName):]); ok {
+				return v, true
+			}
+		}
+	}
+	return nil, false
 }
 
 func (f *flagGroup) parse(context *ParseContext) (*FlagClause, error) {
@@ -89,7 +183,7 @@ loop:
 
 			name := token.Value
 			if token.Type == TokenLong {
-				flag, ok = f.long[name]
+				flag, ok = f.getLong(name)
 				if !ok {
 					if strings.HasPrefix(name, "no-") {
 						name = name[3:]
@@ -101,7 +195,7 @@ loop:
 					return nil, fmt.Errorf("unknown long flag '%s'", flagToken)
 				}
 			} else {
-				flag, ok = f.short[name]
+				flag, ok = f.getShort(name)
 				if !ok {
 					return nil, fmt.Errorf("unknown short flag '%s'", flagToken)
 				}
@@ -142,6 +236,11 @@ loop:
 	return nil, nil
 }
 
+// GetEnvarPrefix will return the actual environment variable prefix.
+func (f *flagGroup) GetEnvarPrefix() string {
+	return f.envarNamePrefix
+}
+
 // FlagClause is a fluid interface used to build flags.
 type FlagClause struct {
 	parserMixin
@@ -155,14 +254,31 @@ type FlagClause struct {
 	placeholder   string
 	hidden        bool
 	setByUser     *bool
+	holder        FlagGroup
 }
 
-func newFlag(name, help string) *FlagClause {
+func newFlag(name, help string, holder FlagGroup, envarNameResolver envarNameResolver) *FlagClause {
 	f := &FlagClause{
-		name: name,
-		help: help,
+		name:   name,
+		help:   help,
+		holder: holder,
 	}
+	f.nameResolver = envarNameResolver
 	return f
+}
+
+func (f *FlagClause) getName() string {
+	name := f.name
+	nextHolder := f.holder
+	for {
+		if subGroup, ok := nextHolder.(*SubFlagGroup); ok {
+			name = subGroup.prefix + name
+			nextHolder = subGroup.holder
+		} else {
+			break
+		}
+	}
+	return name
 }
 
 func (f *FlagClause) setDefault() error {
@@ -205,54 +321,67 @@ func (f *FlagClause) needsValue() bool {
 
 func (f *FlagClause) init() error {
 	if f.required && len(f.defaultValues) > 0 {
-		return fmt.Errorf("required flag '--%s' with default value that will never be used", f.name)
+		return fmt.Errorf("required flag '--%s' with default value that will never be used", f.getName())
 	}
 	if f.value == nil {
-		return fmt.Errorf("no type defined for --%s (eg. .String())", f.name)
+		return fmt.Errorf("no type defined for --%s (eg. .String())", f.getName())
 	}
 	if v, ok := f.value.(repeatableFlag); (!ok || !v.IsCumulative()) && len(f.defaultValues) > 1 {
-		return fmt.Errorf("invalid default for '--%s', expecting single value", f.name)
+		return fmt.Errorf("invalid default for '--%s', expecting single value", f.getName())
 	}
 	return nil
 }
 
-// Dispatch to the given function after the flag is parsed and validated.
+// Action dispatch to the given function after the flag is parsed and validated.
 func (f *FlagClause) Action(action Action) *FlagClause {
 	f.addAction(action)
 	return f
 }
 
+// AddAction works like Action but does not return the current instance.
+// This will fulfill the common interface ActionGroup
+func (f *FlagClause) AddAction(action Action) {
+	f.Action(action)
+}
+
+// PreAction called after parsing completes but before validation and execution.
 func (f *FlagClause) PreAction(action Action) *FlagClause {
 	f.addPreAction(action)
 	return f
 }
 
+// AddPreAction works like PreAction but does not return the current instance.
+// This will fulfill the common interface ActionGroup
+func (f *FlagClause) AddPreAction(action Action) {
+	f.PreAction(action)
+}
+
 // HintAction registers a HintAction (function) for the flag to provide completions
-func (a *FlagClause) HintAction(action HintAction) *FlagClause {
-	a.addHintAction(action)
-	return a
+func (f *FlagClause) HintAction(action HintAction) *FlagClause {
+	f.addHintAction(action)
+	return f
 }
 
 // HintOptions registers any number of options for the flag to provide completions
-func (a *FlagClause) HintOptions(options ...string) *FlagClause {
-	a.addHintAction(func() []string {
+func (f *FlagClause) HintOptions(options ...string) *FlagClause {
+	f.addHintAction(func() []string {
 		return options
 	})
-	return a
+	return f
 }
 
-func (a *FlagClause) EnumVar(target *string, options ...string) {
-	a.parserMixin.EnumVar(target, options...)
-	a.addHintActionBuiltin(func() []string {
+func (f *FlagClause) EnumVar(target *string, options ...string) {
+	f.parserMixin.EnumVar(target, options...)
+	f.addHintActionBuiltin(func() []string {
 		return options
 	})
 }
 
-func (a *FlagClause) Enum(options ...string) (target *string) {
-	a.addHintActionBuiltin(func() []string {
+func (f *FlagClause) Enum(options ...string) (target *string) {
+	f.addHintActionBuiltin(func() []string {
 		return options
 	})
-	return a.parserMixin.Enum(options...)
+	return f.parserMixin.Enum(options...)
 }
 
 // IsSetByUser let to know if the flag was set by the user
@@ -329,4 +458,55 @@ func (f *FlagClause) Bool() (target *bool) {
 	target = new(bool)
 	f.SetValue(newBoolValue(target))
 	return
+}
+
+type SubFlagGroup struct {
+	flagGroup
+	parentEnvarPrefixProvider envarPrefixProvider
+
+	holder FlagGroup
+	prefix string
+}
+
+type envarPrefixProvider func() string
+
+// EnvarNamePrefix will set a prefix for environment variables.
+// This will prevent for duplicating the prefixes for all environment variables.
+func (f *SubFlagGroup) EnvarNamePrefix(prefix string) *SubFlagGroup {
+	f.envarNamePrefix = prefix
+	return f
+}
+
+// Flag defines a new flag with the given long name and help.
+func (f *SubFlagGroup) Flag(name, help string) *FlagClause {
+	return f.newFlag(name, help, f, f.resolveEnvarName)
+}
+
+func (f *SubFlagGroup) resolveEnvarName(name string) string {
+	return f.GetEnvarPrefix() + name
+}
+
+// GetEnvarPrefix will return the actual environment variable prefix.
+func (f *SubFlagGroup) GetEnvarPrefix() string {
+	return f.parentEnvarPrefixProvider() + f.flagGroup.GetEnvarPrefix()
+}
+
+// FlagGroup create a new sub group at this FlagGroup with the given name.
+//
+// This allows grouping flags and prevents duplication of namings.
+func (f *SubFlagGroup) FlagGroup(prefix string) *SubFlagGroup {
+	return f.newFlagGroup(prefix, f, f.GetEnvarPrefix)
+}
+
+// RegisterFlagsOf will execute a registrar for flags.
+// which will be executed before pre-actions and validation to register its flags.
+func (f *SubFlagGroup) RegisterFlagsOf(registrars ...FlagRegistrar) {
+	registerFlagsOf(f, registrars...)
+}
+
+// FlagsOf will execute a registrar for flags for this CmdClause
+// which will be executed before pre-actions and validation to register its flags.
+func (f *SubFlagGroup) FlagsOf(registrars ...FlagRegistrar) *SubFlagGroup {
+	f.RegisterFlagsOf(registrars...)
+	return f
 }

--- a/flags_test.go
+++ b/flags_test.go
@@ -19,7 +19,7 @@ func TestBool(t *testing.T) {
 
 func TestNoBool(t *testing.T) {
 	fg := newFlagGroup()
-	f := fg.Flag("b", "").Default("true")
+	f := fg.newFlag("b", "", nil, nil).Default("true")
 	b := f.Bool()
 	fg.init("")
 	tokens := tokenize([]string{"--no-b"}, false)
@@ -30,7 +30,7 @@ func TestNoBool(t *testing.T) {
 
 func TestNegateNonBool(t *testing.T) {
 	fg := newFlagGroup()
-	f := fg.Flag("b", "")
+	f := fg.newFlag("b", "", nil, nil)
 	f.Int()
 	fg.init("")
 	tokens := tokenize([]string{"--no-b"}, false)
@@ -40,7 +40,7 @@ func TestNegateNonBool(t *testing.T) {
 
 func TestNegativePrefixLongFlag(t *testing.T) {
 	fg := newFlagGroup()
-	f := fg.Flag("no-comment", "")
+	f := fg.newFlag("no-comment", "", nil, nil)
 	b := f.Bool()
 	fg.init("")
 	tokens := tokenize([]string{"--no-comment"}, false)

--- a/global.go
+++ b/global.go
@@ -33,6 +33,18 @@ func Arg(name, help string) *ArgClause {
 	return CommandLine.Arg(name, help)
 }
 
+// FlagsOf will register a registrar for flags for this Application
+// which will be executed before pre-actions and validation to register its flags.
+func FlagsOf(registrars ...FlagRegistrar) *Application {
+	return CommandLine.FlagsOf(registrars...)
+}
+
+// CmdsOf will register a registrar for commands for this Application
+// which will be executed before pre-actions and validation to register its commands.
+func CmdsOf(registrars ...CmdRegistrar) *Application {
+	return CommandLine.CmdsOf(registrars...)
+}
+
 // Parse and return the selected command. Will call the termination handler if
 // an error is encountered.
 func Parse() string {

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,7 @@ require (
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.2.2
+	github.com/stretchr/testify v1.6.1
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -2,9 +2,15 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5Vpd
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
-github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/model.go
+++ b/model.go
@@ -214,7 +214,7 @@ func (a *ArgClause) Model() *ArgModel {
 		Name:        a.name,
 		Help:        a.help,
 		Default:     a.defaultValues,
-		Envar:       a.envar,
+		Envar:       a.getEnvar(),
 		PlaceHolder: a.placeholder,
 		Required:    a.required,
 		Hidden:      a.hidden,
@@ -224,19 +224,26 @@ func (a *ArgClause) Model() *ArgModel {
 
 func (f *flagGroup) Model() *FlagGroupModel {
 	m := &FlagGroupModel{}
-	for _, fl := range f.flagOrder {
-		m.Flags = append(m.Flags, fl.Model())
-	}
+	f.modelRecursive(m)
 	return m
+}
+
+func (f *flagGroup) modelRecursive(target *FlagGroupModel) {
+	for _, fl := range f.flagOrder {
+		target.Flags = append(target.Flags, fl.Model())
+	}
+	for _, subGroup := range f.subGroups {
+		subGroup.modelRecursive(target)
+	}
 }
 
 func (f *FlagClause) Model() *FlagModel {
 	return &FlagModel{
-		Name:        f.name,
+		Name:        f.getName(),
 		Help:        f.help,
 		Short:       rune(f.shorthand),
 		Default:     f.defaultValues,
-		Envar:       f.envar,
+		Envar:       f.getEnvar(),
 		PlaceHolder: f.placeholder,
 		Required:    f.required,
 		Hidden:      f.hidden,

--- a/parser.go
+++ b/parser.go
@@ -138,8 +138,11 @@ func (p *ParseContext) mergeFlags(flags *flagGroup) {
 		if flag.shorthand != 0 {
 			p.flags.short[string(flag.shorthand)] = flag
 		}
-		p.flags.long[flag.name] = flag
+		p.flags.long[flag.getName()] = flag
 		p.flags.flagOrder = append(p.flags.flagOrder, flag)
+	}
+	for _, subGroup := range flags.subGroups {
+		p.mergeFlags(&subGroup.flagGroup)
 	}
 }
 

--- a/registrar.go
+++ b/registrar.go
@@ -1,0 +1,37 @@
+package kingpin
+
+// FlagRegistrar will be executed before pre-actions and validation to register its flags.
+type FlagRegistrar interface {
+	// RegisterFlags will register flags at the given FlagGroup
+	RegisterFlags(FlagGroup)
+}
+
+type FlagRegistrarFunc func(FlagGroup)
+
+func (r FlagRegistrarFunc) RegisterFlags(f FlagGroup) {
+	r(f)
+}
+
+func registerFlagsOf(fg FlagGroup, registrars ...FlagRegistrar) {
+	for _, r := range registrars {
+		r.RegisterFlags(fg)
+	}
+}
+
+// CmdRegistrar will be executed before pre-actions and validation to register its commands.
+type CmdRegistrar interface {
+	// RegisterFlags will register commands at the given Cmd
+	RegisterCommands(Cmd)
+}
+
+type CmdRegistrarFunc func(Cmd)
+
+func (r CmdRegistrarFunc) RegisterCommands(c Cmd) {
+	r(c)
+}
+
+func registerCommandsOf(c Cmd, registrars ...CmdRegistrar) {
+	for _, r := range registrars {
+		r.RegisterCommands(c)
+	}
+}


### PR DESCRIPTION
## Motivation

Creating complex CLI application where you have sub-commands of sub-commands currently are leading to unnecessary complex. The same applies when structure over multiple structs in structs.

## Approach

This solution is focusing on the following parts...

### 1. Do not break existing usages

Important, but requires to be mentioned. I tried a lot of stuff to make all following approaches compatible with the existing API. Everything should work as before and mostly it feels like as before.

### 2. Adding common interfaces to enable delegation of stuff.

1. [`Cmd`](https://github.com/blaubaer/kingpin/blob/extend_for_modules/cmd.go) (primary)
2. [`FlagGroup`](https://github.com/blaubaer/kingpin/blob/extend_for_modules/flags.go) (primary)
3. [`CmdGroup`](https://github.com/blaubaer/kingpin/blob/extend_for_modules/cmd.go) (supporting)
4. [`ActionGroup`](https://github.com/blaubaer/kingpin/blob/extend_for_modules/actions.go) (supporting)
5. [`ArgGroup`](https://github.com/blaubaer/kingpin/blob/extend_for_modules/args.go) (supporting)

### 3. Adding sub-grouping of flags without repeating ourselves

To enable this the [`SubFlagGroup`](https://github.com/blaubaer/kingpin/blob/extend_for_modules/flags.go) was introduced. It can be created by every implementation of [`FlagGroup`](https://github.com/blaubaer/kingpin/blob/extend_for_modules/flags.go) ([`Application`](https://github.com/blaubaer/kingpin/blob/extend_for_modules/app.go), [`CmdClause`](https://github.com/blaubaer/kingpin/blob/extend_for_modules/cmd.go) and [`SubFlagGroup`](https://github.com/blaubaer/kingpin/blob/extend_for_modules/flags.go) itself) by calling the `FlagGroup(perfix string)` function.

Simply explained: Every `SubFlagGroup` will append the prefix to it's children.

Example:
```
Given:
   App -> SubFlagGroup('foo.') -> SubFlagGroup('bar.') -> Flag('some-flag')
After resolution:
   App -> Flag('foo.bar.some-flag')
```

Please see the [examples for a better explanation](https://github.com/blaubaer/kingpin/tree/extend_for_modules/_examples/components_flags).

### 4. Structured environment variables prefixes

Similar to the sub-grouping of the flags this will apply to every kind of grouping. In this case it affects every `FlagGroup` implementation, too. By calling `EnvarNamePrefix(prefix string)` function it will add to the correct grouping environment prefix which all child element (that is environment enabled) will recieve.

Please see the [flag](https://github.com/blaubaer/kingpin/tree/extend_for_modules/_examples/components_flags) and [command](https://github.com/blaubaer/kingpin/tree/extend_for_modules/_examples/components_commands) examples for a better explanation.

### 5. Bring all together with registrars to easily delegate extension of the CLI configuration

1. [`FlagRegistrar` / `FlagRegistrarFunc`](https://github.com/blaubaer/kingpin/blob/extend_for_modules/registrar.go)
    Which is used to enable other objects to define how they want to extend flags without having access to the whole application or command tree.
   
    Please see the [examples for a better explanation](https://github.com/blaubaer/kingpin/tree/extend_for_modules/_examples/components_flags).

2. [`CmdRegistrar` / `CmdRegistrarFunc`](https://github.com/blaubaer/kingpin/blob/extend_for_modules/registrar.go)
    Similar to `FlagRegistrar` but is able to add other commands and arguments.

    Please see the [examples for a better explanation](https://github.com/blaubaer/kingpin/tree/extend_for_modules/_examples/components_commands).

### Required changes

As [`stretchr/testify`](https://github.com/stretchr/testify#supported-go-versions) does not longer support older versions (before go.1.13) golang versions without go modules cannot longer use regular builds using `go get -t -v ./...` because they will receive the latest version of it which is not longer compatible with versions before go 1.13.

⚠️ But this is required for any upcoming change anyway - this has nothing to do with this change itself.

## Outlook

This might help in the future to also enable stuff like automatic injection based on struct annotations.

## Finally

Sorry for the big change, but one piece alone does not show the value of it. Only everything together. And I also added some method comments, aligned receiver namings, ... 😄 