### PR TITLE
expand env variables

### DIFF
--- a/envar.go
+++ b/envar.go
@@ -24,7 +24,7 @@ func (e *envarMixin) GetEnvarValue() string {
 	if e.noEnvar || e.envar == "" {
 		return ""
 	}
-	return os.Getenv(e.envar)
+	return os.ExpandEnv(os.Getenv(e.envar))
 }
 
 func (e *envarMixin) GetSplitEnvarValue() []string {

--- a/flags_test.go
+++ b/flags_test.go
@@ -157,6 +157,18 @@ func TestRequiredWithEnvar(t *testing.T) {
 	assert.Equal(t, 123, *flag)
 }
 
+func TestExpandEnvar(t *testing.T) {
+	os.Setenv("TEST_PORT", "8080")
+	os.Setenv("TEST_HOST", "http://localhost")
+	os.Setenv("TEST_URL", "${TEST_HOST}:$TEST_PORT")
+
+	app := newTestApp()
+	flag := app.Flag("t", "").Envar("TEST_URL").Required().String()
+	_, err := app.Parse([]string{})
+	assert.NoError(t, err)
+	assert.Equal(t, "http://localhost:8080", *flag)
+}
+
 func TestSubcommandFlagRequiredWithEnvar(t *testing.T) {
 	os.Setenv("TEST_ENVAR", "123")
 	app := newTestApp()


### PR DESCRIPTION
Hi!

I use the kingpin at work and recently wrote an ugly-looking workaround for the ENV variables, which contains other ENVs as the values. I investigated the kingpin's sources and saw that it fixes in one line here...so, here I am, with my PR =)