### PR TITLE
Extend DurationVar() to support days, weeks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2
+	github.com/xhit/go-str2duration v1.2.0
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -8,3 +8,5 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/xhit/go-str2duration v1.2.0 h1:BcV5u025cITWxEQKGWr1URRzrcXtu7uk8+luz3Yuhwc=
+github.com/xhit/go-str2duration v1.2.0/go.mod h1:3cPSlfZlUHVlneIVfePFWcJZsuwf+P1v2SRTV4cUmp4=

--- a/values.go
+++ b/values.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/alecthomas/units"
+	"github.com/xhit/go-str2duration"
 )
 
 // NOTE: Most of the base type values were lifted from:
@@ -138,7 +139,7 @@ func newDurationValue(p *time.Duration) *durationValue {
 }
 
 func (d *durationValue) Set(s string) error {
-	v, err := time.ParseDuration(s)
+	v, err := str2duration.Str2Duration(s)
 	*d = durationValue(v)
 	return err
 }


### PR DESCRIPTION
Use the open source package str2duration (which is a wrapper)
around time.ParseDuration, to parse duration args from strings.
This package supports more time formats, including days and weeks.

This closes #328 