### PR TITLE
Switch to text/template with trim whitespace directive

### DIFF
--- a/cmd/genvalues/main.go
+++ b/cmd/genvalues/main.go
@@ -5,8 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-
-	"github.com/alecthomas/template"
+	"text/template"
 )
 
 const (
@@ -37,9 +36,9 @@ func (f *{{.|ValueName}}) String() string { return {{.|Format}} }
 
 {{if .Help}}
 // {{.Help}}
-{{else}}\
+{{else -}}
 // {{.|Name}} parses the next command-line value as {{.Type}}.
-{{end}}\
+{{end -}}
 func (p *parserMixin) {{.|Name}}() (target *{{.Type}}) {
 	target = new({{.Type}})
 	p.{{.|Name}}Var(target)

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/alecthomas/kingpin
 
 require (
-	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
-github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/templates.go
+++ b/templates.go
@@ -1,181 +1,181 @@
 package kingpin
 
 // Default usage template.
-var DefaultUsageTemplate = `{{define "FormatCommand"}}\
-{{if .FlagSummary}} {{.FlagSummary}}{{end}}\
-{{range .Args}}{{if not .Hidden}} {{if not .Required}}[{{end}}{{if .PlaceHolder}}{{.PlaceHolder}}{{else}}<{{.Name}}>{{end}}{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}{{end}}\
-{{end}}\
+var DefaultUsageTemplate = `{{define "FormatCommand" -}}
+{{if .FlagSummary}} {{.FlagSummary}}{{end -}}
+{{range .Args}}{{if not .Hidden}} {{if not .Required}}[{{end}}{{if .PlaceHolder}}{{.PlaceHolder}}{{else}}<{{.Name}}>{{end}}{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}{{end -}}
+{{end -}}
 
-{{define "FormatCommands"}}\
-{{range .FlattenedCommands}}\
-{{if not .Hidden}}\
+{{define "FormatCommands" -}}
+{{range .FlattenedCommands -}}
+{{if not .Hidden -}}
   {{.FullCommand}}{{if .Default}}*{{end}}{{template "FormatCommand" .}}
 {{.Help|Wrap 4}}
-{{end}}\
-{{end}}\
-{{end}}\
+{{end -}}
+{{end -}}
+{{end -}}
 
-{{define "FormatUsage"}}\
+{{define "FormatUsage" -}}
 {{template "FormatCommand" .}}{{if .Commands}} <command> [<args> ...]{{end}}
 {{if .Help}}
-{{.Help|Wrap 0}}\
-{{end}}\
+{{.Help|Wrap 0 -}}
+{{end -}}
 
-{{end}}\
+{{end -}}
 
-{{if .Context.SelectedCommand}}\
+{{if .Context.SelectedCommand -}}
 usage: {{.App.Name}} {{.Context.SelectedCommand}}{{template "FormatUsage" .Context.SelectedCommand}}
-{{else}}\
+{{ else -}}
 usage: {{.App.Name}}{{template "FormatUsage" .App}}
-{{end}}\
-{{if .Context.Flags}}\
+{{end}}
+{{if .Context.Flags -}}
 Flags:
 {{.Context.Flags|FlagsToTwoColumns|FormatTwoColumns}}
-{{end}}\
-{{if .Context.Args}}\
+{{end -}}
+{{if .Context.Args -}}
 Args:
 {{.Context.Args|ArgsToTwoColumns|FormatTwoColumns}}
-{{end}}\
-{{if .Context.SelectedCommand}}\
-{{if len .Context.SelectedCommand.Commands}}\
+{{end -}}
+{{if .Context.SelectedCommand -}}
+{{if len .Context.SelectedCommand.Commands -}}
 Subcommands:
 {{template "FormatCommands" .Context.SelectedCommand}}
-{{end}}\
-{{else if .App.Commands}}\
+{{end -}}
+{{else if .App.Commands -}}
 Commands:
 {{template "FormatCommands" .App}}
-{{end}}\
+{{end -}}
 `
 
 // Usage template where command's optional flags are listed separately
-var SeparateOptionalFlagsUsageTemplate = `{{define "FormatCommand"}}\
-{{if .FlagSummary}} {{.FlagSummary}}{{end}}\
-{{range .Args}}{{if not .Hidden}} {{if not .Required}}[{{end}}{{if .PlaceHolder}}{{.PlaceHolder}}{{else}}<{{.Name}}>{{end}}{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}{{end}}\
-{{end}}\
+var SeparateOptionalFlagsUsageTemplate = `{{define "FormatCommand" -}}
+{{if .FlagSummary}} {{.FlagSummary}}{{end -}}
+{{range .Args}}{{if not .Hidden}} {{if not .Required}}[{{end}}{{if .PlaceHolder}}{{.PlaceHolder}}{{else}}<{{.Name}}>{{end}}{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}{{end -}}
+{{end -}}
 
-{{define "FormatCommands"}}\
-{{range .FlattenedCommands}}\
-{{if not .Hidden}}\
+{{define "FormatCommands" -}}
+{{range .FlattenedCommands -}}
+{{if not .Hidden -}}
   {{.FullCommand}}{{if .Default}}*{{end}}{{template "FormatCommand" .}}
 {{.Help|Wrap 4}}
-{{end}}\
-{{end}}\
-{{end}}\
+{{end -}}
+{{end -}}
+{{end -}}
 
-{{define "FormatUsage"}}\
+{{define "FormatUsage" -}}
 {{template "FormatCommand" .}}{{if .Commands}} <command> [<args> ...]{{end}}
 {{if .Help}}
-{{.Help|Wrap 0}}\
-{{end}}\
+{{.Help|Wrap 0 -}}
+{{end -}}
 
-{{end}}\
-{{if .Context.SelectedCommand}}\
+{{end -}}
+{{if .Context.SelectedCommand -}}
 usage: {{.App.Name}} {{.Context.SelectedCommand}}{{template "FormatUsage" .Context.SelectedCommand}}
-{{else}}\
+{{else -}}
 usage: {{.App.Name}}{{template "FormatUsage" .App}}
-{{end}}\
+{{end -}}
 
-{{if .Context.Flags|RequiredFlags}}\
+{{if .Context.Flags|RequiredFlags -}}
 Required flags:
 {{.Context.Flags|RequiredFlags|FlagsToTwoColumns|FormatTwoColumns}}
-{{end}}\
-{{if  .Context.Flags|OptionalFlags}}\
+{{end -}}
+{{if  .Context.Flags|OptionalFlags -}}
 Optional flags:
 {{.Context.Flags|OptionalFlags|FlagsToTwoColumns|FormatTwoColumns}}
-{{end}}\
-{{if .Context.Args}}\
+{{end -}}
+{{if .Context.Args -}}
 Args:
 {{.Context.Args|ArgsToTwoColumns|FormatTwoColumns}}
-{{end}}\
-{{if .Context.SelectedCommand}}\
+{{end -}}
+{{if .Context.SelectedCommand -}}
 Subcommands:
-{{if .Context.SelectedCommand.Commands}}\
+{{if .Context.SelectedCommand.Commands -}}
 {{template "FormatCommands" .Context.SelectedCommand}}
-{{end}}\
-{{else if .App.Commands}}\
+{{end -}}
+{{else if .App.Commands -}}
 Commands:
 {{template "FormatCommands" .App}}
-{{end}}\
+{{end -}}
 `
 
 // Usage template with compactly formatted commands.
-var CompactUsageTemplate = `{{define "FormatCommand"}}\
-{{if .FlagSummary}} {{.FlagSummary}}{{end}}\
-{{range .Args}}{{if not .Hidden}} {{if not .Required}}[{{end}}{{if .PlaceHolder}}{{.PlaceHolder}}{{else}}<{{.Name}}>{{end}}{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}{{end}}\
-{{end}}\
+var CompactUsageTemplate = `{{define "FormatCommand" -}}
+{{if .FlagSummary}} {{.FlagSummary}}{{end -}}
+{{range .Args}}{{if not .Hidden}} {{if not .Required}}[{{end}}{{if .PlaceHolder}}{{.PlaceHolder}}{{else}}<{{.Name}}>{{end}}{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}{{end -}}
+{{end -}}
 
-{{define "FormatCommandList"}}\
-{{range .}}\
-{{if not .Hidden}}\
+{{define "FormatCommandList" -}}
+{{range . -}}
+{{if not .Hidden -}}
 {{.Depth|Indent}}{{.Name}}{{if .Default}}*{{end}}{{template "FormatCommand" .}}
-{{end}}\
-{{template "FormatCommandList" .Commands}}\
-{{end}}\
-{{end}}\
+{{end -}}
+{{template "FormatCommandList" .Commands -}}
+{{end -}}
+{{end -}}
 
-{{define "FormatUsage"}}\
+{{define "FormatUsage" -}}
 {{template "FormatCommand" .}}{{if .Commands}} <command> [<args> ...]{{end}}
 {{if .Help}}
-{{.Help|Wrap 0}}\
-{{end}}\
+{{.Help|Wrap 0 -}}
+{{end -}}
 
-{{end}}\
+{{end -}}
 
-{{if .Context.SelectedCommand}}\
+{{if .Context.SelectedCommand -}}
 usage: {{.App.Name}} {{.Context.SelectedCommand}}{{template "FormatUsage" .Context.SelectedCommand}}
-{{else}}\
+{{else -}}
 usage: {{.App.Name}}{{template "FormatUsage" .App}}
-{{end}}\
-{{if .Context.Flags}}\
+{{end -}}
+{{if .Context.Flags -}}
 Flags:
 {{.Context.Flags|FlagsToTwoColumns|FormatTwoColumns}}
-{{end}}\
-{{if .Context.Args}}\
+{{end -}}
+{{if .Context.Args -}}
 Args:
 {{.Context.Args|ArgsToTwoColumns|FormatTwoColumns}}
-{{end}}\
-{{if .Context.SelectedCommand}}\
-{{if .Context.SelectedCommand.Commands}}\
+{{end -}}
+{{if .Context.SelectedCommand -}}
+{{if .Context.SelectedCommand.Commands -}}
 Commands:
   {{.Context.SelectedCommand}}
 {{template "FormatCommandList" .Context.SelectedCommand.Commands}}
-{{end}}\
-{{else if .App.Commands}}\
+{{end -}}
+{{else if .App.Commands -}}
 Commands:
 {{template "FormatCommandList" .App.Commands}}
-{{end}}\
+{{end -}}
 `
 
-var ManPageTemplate = `{{define "FormatFlags"}}\
-{{range .Flags}}\
-{{if not .Hidden}}\
+var ManPageTemplate = `{{define "FormatFlags" -}}
+{{range .Flags -}}
+{{if not .Hidden -}}
 .TP
-\fB{{if .Short}}-{{.Short|Char}}, {{end}}--{{.Name}}{{if not .IsBoolFlag}}={{.FormatPlaceHolder}}{{end}}\\fR
+\fB{{if .Short}}-{{.Short|Char}}, {{end}}--{{.Name}}{{if not .IsBoolFlag}}={{.FormatPlaceHolder}}{{end -}}\fR
 {{.Help}}
-{{end}}\
-{{end}}\
-{{end}}\
+{{end -}}
+{{end -}}
+{{end -}}
 
-{{define "FormatCommand"}}\
-{{if .FlagSummary}} {{.FlagSummary}}{{end}}\
-{{range .Args}}{{if not .Hidden}} {{if not .Required}}[{{end}}{{if .PlaceHolder}}{{.PlaceHolder}}{{else}}<{{.Name}}>{{end}}{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}{{end}}\
-{{end}}\
+{{define "FormatCommand" -}}
+{{if .FlagSummary}} {{.FlagSummary}}{{end -}}
+{{range .Args}}{{if not .Hidden}} {{if not .Required}}[{{end}}{{if .PlaceHolder}}{{.PlaceHolder}}{{else}}<{{.Name}}>{{end}}{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}{{end -}}
+{{end -}}
 
-{{define "FormatCommands"}}\
-{{range .FlattenedCommands}}\
-{{if not .Hidden}}\
+{{define "FormatCommands" -}}
+{{range .FlattenedCommands -}}
+{{if not .Hidden -}}
 .SS
-\fB{{.FullCommand}}{{template "FormatCommand" .}}\\fR
+\fB{{.FullCommand}}{{template "FormatCommand" . -}}\fR
 .PP
 {{.Help}}
-{{template "FormatFlags" .}}\
-{{end}}\
-{{end}}\
-{{end}}\
+{{template "FormatFlags" . -}}
+{{end -}}
+{{end -}}
+{{end -}}
 
-{{define "FormatUsage"}}\
-{{template "FormatCommand" .}}{{if .Commands}} <command> [<args> ...]{{end}}\\fR
-{{end}}\
+{{define "FormatUsage" -}}
+{{template "FormatCommand" .}}{{if .Commands}} <command> [<args> ...]{{end -}}\fR
+{{end -}}
 
 .TH {{.App.Name}} 1 {{.App.Version}} "{{.App.Author}}"
 .SH "NAME"
@@ -186,50 +186,50 @@ var ManPageTemplate = `{{define "FormatFlags"}}\
 .SH "DESCRIPTION"
 {{.App.Help}}
 .SH "OPTIONS"
-{{template "FormatFlags" .App}}\
-{{if .App.Commands}}\
+{{template "FormatFlags" .App -}}
+{{if .App.Commands -}}
 .SH "COMMANDS"
-{{template "FormatCommands" .App}}\
-{{end}}\
+{{template "FormatCommands" .App -}}
+{{end -}}
 `
 
 // Default usage template.
-var LongHelpTemplate = `{{define "FormatCommand"}}\
-{{if .FlagSummary}} {{.FlagSummary}}{{end}}\
-{{range .Args}}{{if not .Hidden}} {{if not .Required}}[{{end}}{{if .PlaceHolder}}{{.PlaceHolder}}{{else}}<{{.Name}}>{{end}}{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}{{end}}\
-{{end}}\
+var LongHelpTemplate = `{{define "FormatCommand" -}}
+{{if .FlagSummary}} {{.FlagSummary}}{{end -}}
+{{range .Args}}{{if not .Hidden}} {{if not .Required}}[{{end}}{{if .PlaceHolder}}{{.PlaceHolder}}{{else}}<{{.Name}}>{{end}}{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}{{end -}}
+{{end -}}
 
-{{define "FormatCommands"}}\
-{{range .FlattenedCommands}}\
-{{if not .Hidden}}\
+{{define "FormatCommands" -}}
+{{range .FlattenedCommands -}}
+{{if not .Hidden -}}
   {{.FullCommand}}{{template "FormatCommand" .}}
 {{.Help|Wrap 4}}
 {{with .Flags|FlagsToTwoColumns}}{{FormatTwoColumnsWithIndent . 4 2}}{{end}}
-{{end}}\
-{{end}}\
-{{end}}\
+{{end -}}
+{{end -}}
+{{end -}}
 
-{{define "FormatUsage"}}\
+{{define "FormatUsage" -}}
 {{template "FormatCommand" .}}{{if .Commands}} <command> [<args> ...]{{end}}
 {{if .Help}}
-{{.Help|Wrap 0}}\
-{{end}}\
+{{.Help|Wrap 0 -}}
+{{end -}}
 
-{{end}}\
+{{end -}}
 
 usage: {{.App.Name}}{{template "FormatUsage" .App}}
-{{if .Context.Flags}}\
+{{if .Context.Flags -}}
 Flags:
 {{.Context.Flags|FlagsToTwoColumns|FormatTwoColumns}}
-{{end}}\
-{{if .Context.Args}}\
+{{end -}}
+{{if .Context.Args -}}
 Args:
 {{.Context.Args|ArgsToTwoColumns|FormatTwoColumns}}
-{{end}}\
-{{if .App.Commands}}\
+{{end -}}
+{{if .App.Commands -}}
 Commands:
 {{template "FormatCommands" .App}}
-{{end}}\
+{{end -}}
 `
 
 var BashCompletionTemplate = `

--- a/usage.go
+++ b/usage.go
@@ -6,8 +6,7 @@ import (
 	"go/doc"
 	"io"
 	"strings"
-
-	"github.com/alecthomas/template"
+	"text/template"
 )
 
 var (

--- a/usage_test.go
+++ b/usage_test.go
@@ -80,7 +80,7 @@ func TestUsageFuncs(t *testing.T) {
 
 func TestCmdClause_HelpLong(t *testing.T) {
 	var buf bytes.Buffer
-	tpl := `{{define "FormatUsage"}}{{.HelpLong}}{{end}}\
+	tpl := `{{define "FormatUsage"}}{{.HelpLong}}{{end -}}
 {{template "FormatUsage" .Context.SelectedCommand}}`
 
 	a := New("test", "Test").Writer(&buf).Terminate(nil)


### PR DESCRIPTION
I am interested in removing the github.com/alecthomas/template dependency because the upgrade from Unicode 13 to Unicode 15 triggers a test failure: https://go.googlesource.com/go/+/def0be5e34d6657c84407c8afe4ace05d10d1848

Instead of relying on this old copy, switch to text/template. The whitespace trimming was added in Go 1.6:
https://go.dev/doc/go1.6#template

I generated this change using `M-x replace-string }}\ -}}`