### PR TITLE
Update values.go

### DIFF
--- a/values.go
+++ b/values.go
@@ -139,7 +139,7 @@ func newDurationValue(p *time.Duration) *durationValue {
 }
 
 func (d *durationValue) Set(s string) error {
-	v, err := str2duration.Str2Duration(s)
+	v, err := str2duration.ParseDuration(s)
 	*d = durationValue(v)
 	return err
 }


### PR DESCRIPTION
Based on https://github.com/xhit/go-str2duration/blob/master/str2duration.go, the function name should be ParseDuration instead.