### PR TITLE
Handle --version just like --help

### DIFF
--- a/app.go
+++ b/app.go
@@ -413,6 +413,10 @@ func (a *Application) setDefaults(context *ParseContext) error {
 			if flag.name == "help" {
 				return nil
 			}
+
+			if flag.name == "version" {
+				return nil
+			}
 			flagElements[flag.name] = element
 		}
 	}

--- a/app_test.go
+++ b/app_test.go
@@ -434,3 +434,14 @@ func TestCmdValidation(t *testing.T) {
 	_, err = c.Parse([]string{"cmd", "--a", "A"})
 	assert.NoError(t, err)
 }
+
+func TestVersion(t *testing.T) {
+	c := newTestApp()
+	c.Flag("config", "path to config file").Default("config.yaml").ExistingFile()
+	c.Version("1.0.0")
+
+	// the pre-action for version should be executed without running validation
+	// for ExistingFile
+	_, err := c.Parse([]string{"--version"})
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
When the version flag is passed, the application should do nothing but print the version and exit. But currently, the pre-action for the version flag gets executed AFTER the default for all the other flags are set.

Setting defaults involves validation like checking for file's existence etc. These validation are not necessary when the --version flag is passed. This PR fixes that

### Example scenario where it was failing

```go
var (
	config = kingpin.Flag("config", "path to config").Short('c').Default("config.yaml").ExistingFile()
)

func main() {
	kingpin.Version("0.0.1")
	kingpin.Parse()

	// ...
}
```

Would throw this error:
```
 ➜  go run . --version
main: error: path 'config.yaml' does not exist, try --help
exit status 1
```