### PR TITLE
Do not pass command name to `--completion-bash` argument in ZSH template

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -248,7 +248,7 @@ complete -F _{{.App.Name}}_bash_autocomplete -o default {{.App.Name}}
 var ZshCompletionTemplate = `#compdef {{.App.Name}}
 
 _{{.App.Name}}() {
-    local matches=($(${words[1]} --completion-bash "${(@)words[1,$CURRENT]}"))
+    local matches=($(${words[1]} --completion-bash "${(@)words[2,$CURRENT]}"))
     compadd -a matches
 
     if [[ $compstate[nmatches] -eq 0 && $words[$CURRENT] != -* ]]; then


### PR DESCRIPTION
Sub-commands and sub-commands flags are not autocompleted correctly in ZSH.
This is because in the ZSH template, the argument passed to `--completion-bash` begins with the command name.

The issue can be reproduced in `_examples/completion`: running `./completion nc -- ` returns identical autocompletion values as the `./completion -- ` alone.

Incorrect invocation of `--completion-bash` with the command name:
```sh
grzegorz@mbp kingpin % ./completion --completion-bash ./completion nc -- 
--help
--flag-1
--flag-2
```  

Fixed invocation of `--completion-bash` without the command name:
```sh
grzegorz@mbp kingpin % ./completion --completion-bash nc --             
--nop-flag
--host
--port
--format
--host-with-multi
--host-with-multi-options
--format-with-override-1
--format-with-override-2
--help
--flag-1
--flag-2
```

This PR fixes the passed arguments by starting from the second word (just like the bash template).