### PR TITLE
Update renovate config to run go mod tidy

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -8,4 +8,8 @@
     "group:allNonMajor",
     "schedule:earlyMondays", // Run once a week.
   ],
+  postUpdateOptions: [
+    "gomodTidy",
+    "gomodUpdateImportPaths"
+  ]
 }


### PR DESCRIPTION
Adds options to run `go mod tidy` after an update and to update import paths in case there's a major update of a dependency.