### PR TITLE
Allow linker to perform deadcode elimination for programs using kingpin

### DIFF
--- a/app.go
+++ b/app.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"regexp"
 	"strings"
-	"text/template"
 )
 
 var (
@@ -28,17 +27,20 @@ type Application struct {
 	Name string
 	Help string
 
-	author         string
-	version        string
-	errorWriter    io.Writer // Destination for errors.
-	usageWriter    io.Writer // Destination for usage
-	usageTemplate  string
-	usageFuncs     template.FuncMap
-	validator      ApplicationValidator
-	terminate      func(status int) // See Terminate()
-	noInterspersed bool             // can flags be interspersed with args (or must they come first)
-	defaultEnvars  bool
-	completion     bool
+	author           string
+	version          string
+	errorWriter      io.Writer // Destination for errors.
+	usageWriter      io.Writer // Destination for usage
+	hiddenHelpWriter io.Writer // Desitination for hidden help commands.
+	usageTemplate    string
+	usageFuncs       map[string]interface{}
+	templateRenderer func(a *Application, context *ParseContext, indent int, tmpl string) error
+	usageRenderer    UsageRenderer
+	validator        ApplicationValidator
+	terminate        func(status int) // See Terminate()
+	noInterspersed   bool             // can flags be interspersed with args (or must they come first)
+	defaultEnvars    bool
+	completion       bool
 
 	// Help flag. Exposed for user customisation.
 	HelpFlag *FlagClause
@@ -51,12 +53,12 @@ type Application struct {
 // New creates a new Kingpin application instance.
 func New(name, help string) *Application {
 	a := &Application{
-		Name:          name,
-		Help:          help,
-		errorWriter:   os.Stderr, // Left for backwards compatibility purposes.
-		usageWriter:   os.Stderr,
-		usageTemplate: DefaultUsageTemplate,
-		terminate:     os.Exit,
+		Name:             name,
+		Help:             help,
+		errorWriter:      os.Stderr, // Left for backwards compatibility purposes.
+		usageWriter:      os.Stderr,
+		hiddenHelpWriter: os.Stdout,
+		terminate:        os.Exit,
 	}
 	a.flagGroup = newFlagGroup()
 	a.argGroup = newArgGroup()
@@ -73,9 +75,21 @@ func New(name, help string) *Application {
 	return a
 }
 
+// renderHiddenFlag renders usage for hidden help flags (--help-long, --help-man, etc.).
+// A custom UsageRenderer does NOT override these — they are distinct output formats
+// (man pages, completion scripts) that should always produce their advertised output.
+// UsageFuncs overrides ARE applied, since they provide template helper functions that
+// may be needed by the template path.
+func (a *Application) renderHiddenFlag(c *ParseContext, renderer UsageRenderer, tmpl string) error {
+	if a.usageFuncs != nil && a.templateRenderer != nil {
+		return a.templateRenderer(a, c, 2, tmpl)
+	}
+	return a.usageForContextWithUsageRenderer(c, 2, renderer)
+}
+
 func (a *Application) generateLongHelp(c *ParseContext) error {
-	a.Writer(os.Stdout)
-	if err := a.UsageForContextWithTemplate(c, 2, LongHelpTemplate); err != nil {
+	a.Writer(a.hiddenHelpWriter)
+	if err := a.renderHiddenFlag(c, RenderLongHelp, LongHelpTemplate); err != nil {
 		return err
 	}
 	a.terminate(0)
@@ -83,8 +97,8 @@ func (a *Application) generateLongHelp(c *ParseContext) error {
 }
 
 func (a *Application) generateManPage(c *ParseContext) error {
-	a.Writer(os.Stdout)
-	if err := a.UsageForContextWithTemplate(c, 2, ManPageTemplate); err != nil {
+	a.Writer(a.hiddenHelpWriter)
+	if err := a.renderHiddenFlag(c, RenderManPage, ManPageTemplate); err != nil {
 		return err
 	}
 	a.terminate(0)
@@ -92,8 +106,8 @@ func (a *Application) generateManPage(c *ParseContext) error {
 }
 
 func (a *Application) generateBashCompletionScript(c *ParseContext) error {
-	a.Writer(os.Stdout)
-	if err := a.UsageForContextWithTemplate(c, 2, BashCompletionTemplate); err != nil {
+	a.Writer(a.hiddenHelpWriter)
+	if err := a.renderHiddenFlag(c, RenderBashCompletion, BashCompletionTemplate); err != nil {
 		return err
 	}
 	a.terminate(0)
@@ -101,8 +115,8 @@ func (a *Application) generateBashCompletionScript(c *ParseContext) error {
 }
 
 func (a *Application) generateZSHCompletionScript(c *ParseContext) error {
-	a.Writer(os.Stdout)
-	if err := a.UsageForContextWithTemplate(c, 2, ZshCompletionTemplate); err != nil {
+	a.Writer(a.hiddenHelpWriter)
+	if err := a.renderHiddenFlag(c, RenderZshCompletion, ZshCompletionTemplate); err != nil {
 		return err
 	}
 	a.terminate(0)
@@ -110,8 +124,8 @@ func (a *Application) generateZSHCompletionScript(c *ParseContext) error {
 }
 
 func (a *Application) generateFishCompletionScript(c *ParseContext) error {
-	a.Writer(os.Stdout)
-	if err := a.UsageForContextWithTemplate(c, 2, FishCompletionTemplate); err != nil {
+	a.Writer(a.hiddenHelpWriter)
+	if err := a.renderHiddenFlag(c, RenderFishCompletion, FishCompletionTemplate); err != nil {
 		return err
 	}
 	a.terminate(0)
@@ -152,22 +166,47 @@ func (a *Application) ErrorWriter(w io.Writer) *Application {
 	return a
 }
 
-// UsageWriter sets the io.Writer to use for errors.
+// UsageWriter sets the io.Writer to use for usage.
 func (a *Application) UsageWriter(w io.Writer) *Application {
 	a.usageWriter = w
 	return a
 }
 
-// UsageTemplate specifies the text template to use when displaying usage
-// information. The default is UsageTemplate.
-func (a *Application) UsageTemplate(template string) *Application {
-	a.usageTemplate = template
+// HiddenHelpWriter sets the io.Writer to use for usage of hidden help commands.
+func (a *Application) HiddenHelpWriter(w io.Writer) *Application {
+	a.hiddenHelpWriter = w
 	return a
 }
 
-// UsageFuncs adds extra functions that can be used in the usage template.
-func (a *Application) UsageFuncs(funcs template.FuncMap) *Application {
+// UsageTemplate specifies the text template to use when displaying usage
+// information. The default is UsageTemplate.
+//
+// Note: calling this method causes text/template to be linked into the binary,
+// which prevents dead code elimination of reflect.MethodByName. Programs that
+// want smaller binaries should use UsageRenderer instead.
+func (a *Application) UsageTemplate(template string) *Application {
+	a.usageTemplate = template
+	a.templateRenderer = templateRenderFunc
+	return a
+}
+
+// UsageFuncs adds extra functions that can be used in the usage template
+//
+// Note: calling this method causes text/template to be linked into the binary,
+// which prevents dead code elimination of reflect.MethodByName. Programs that
+// want smaller binaries should use UsageRenderer instead..
+func (a *Application) UsageFuncs(funcs map[string]interface{}) *Application {
 	a.usageFuncs = funcs
+	a.templateRenderer = templateRenderFunc
+	return a
+}
+
+// UsageRenderer registers a custom UsageRenderer for the primary --help output.
+// It does not affect hidden help flags (--help-long, --help-man, completion scripts),
+// which always use their built-in renderers or the template path if UsageFuncs is set.
+// For backward compatibility, UsageTemplate takes precedence over UsageRenderer.
+func (a *Application) UsageRenderer(fn UsageRenderer) *Application {
+	a.usageRenderer = fn
 	return a
 }
 

--- a/dce_test.go
+++ b/dce_test.go
@@ -1,0 +1,49 @@
+package kingpin
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDeadCodeElimination verifies that programs using kingpin's default
+// UsageRenderer do not link in reflect.MethodByName, which is the key
+// indicator that dead code elimination is working.
+func TestDeadCodeElimination(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("go tool nm not reliable on Windows")
+	}
+
+	dir := t.TempDir()
+	filename := filepath.Join(dir, "main.go")
+	err := os.WriteFile(filename, []byte(`package main
+
+import (
+	"os"
+
+	"github.com/alecthomas/kingpin/v2"
+)
+
+func main() {
+	app := kingpin.New("test", "A test app.")
+	app.UsageRenderer(kingpin.RenderDefault)
+	app.Flag("verbose", "Enable verbose mode.").Bool()
+	app.Command("sub", "A subcommand.")
+	app.Parse(os.Args[1:])
+}
+`), 0o600)
+	require.NoError(t, err)
+
+	binPath := filepath.Join(dir, "test_binary")
+	buf, err := exec.Command("go", "build", "-trimpath", "-o", binPath, filename).CombinedOutput()
+	require.NoError(t, err, "go build failed: %s", buf)
+
+	buf, err = exec.Command("go", "tool", "nm", binPath).CombinedOutput()
+	require.NoError(t, err, "go tool nm failed: %s", buf)
+
+	require.NotContains(t, string(buf), "MethodByName", "text/template was not eliminated by dead code elimination")
+}

--- a/usage.go
+++ b/usage.go
@@ -2,18 +2,18 @@ package kingpin
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"go/doc"
 	"io"
 	"strings"
-	"text/template"
 )
 
-var (
-	preIndent = "  "
-)
+var preIndent = "  "
 
-func formatTwoColumns(w io.Writer, indent, padding, width int, rows [][2]string) {
+// FormatTwoColumns formats rows of two-column data (e.g., flags and their descriptions)
+// into aligned output written to w, with the given indent, padding, and total width.
+func FormatTwoColumns(w io.Writer, indent, padding, width int, rows [][2]string) {
 	// Find size of first column.
 	s := 0
 	for _, row := range rows {
@@ -45,7 +45,7 @@ func formatTwoColumns(w io.Writer, indent, padding, width int, rows [][2]string)
 func (a *Application) Usage(args []string) {
 	context, err := a.parseContext(true, args)
 	a.FatalIfError(err, "")
-	if err := a.UsageForContextWithTemplate(context, 2, a.usageTemplate); err != nil {
+	if err := a.UsageForContext(context); err != nil {
 		panic(err)
 	}
 }
@@ -72,7 +72,8 @@ func formatCmdUsage(app *ApplicationModel, cmd *CmdModel) string {
 	return strings.Join(s, " ")
 }
 
-func formatFlag(haveShort bool, flag *FlagModel) string {
+// FormatFlagCompact formats a flag name without placeholder value for compact display.
+func FormatFlagCompact(haveShort bool, flag *FlagModel) string {
 	flagString := ""
 	flagName := flag.Name
 	if flag.IsBoolFlag() {
@@ -87,6 +88,12 @@ func formatFlag(haveShort bool, flag *FlagModel) string {
 			flagString += fmt.Sprintf("--%s", flagName)
 		}
 	}
+	return flagString
+}
+
+// FormatFlag formats a flag with its placeholder value and cumulative indicator.
+func FormatFlag(haveShort bool, flag *FlagModel) string {
+	flagString := FormatFlagCompact(haveShort, flag)
 	if !flag.IsBoolFlag() {
 		flagString += fmt.Sprintf("=%s", flag.FormatPlaceHolder())
 	}
@@ -96,130 +103,62 @@ func formatFlag(haveShort bool, flag *FlagModel) string {
 	return flagString
 }
 
-type templateParseContext struct {
-	SelectedCommand *CmdModel
-	*FlagGroupModel
-	*ArgGroupModel
-}
-
-type templateContext struct {
-	App     *ApplicationModel
-	Width   int
-	Context *templateParseContext
-}
-
 // UsageForContext displays usage information from a ParseContext (obtained from
 // Application.ParseContext() or Action(f) callbacks).
 func (a *Application) UsageForContext(context *ParseContext) error {
-	return a.UsageForContextWithTemplate(context, 2, a.usageTemplate)
+	if a.usageTemplate != "" && a.templateRenderer != nil {
+		return a.templateRenderer(a, context, 2, a.usageTemplate)
+	}
+
+	if a.usageRenderer != nil {
+		return a.usageForContextWithUsageRenderer(context, 2, a.usageRenderer)
+	}
+
+	if a.usageFuncs != nil && a.templateRenderer != nil {
+		return a.templateRenderer(a, context, 2, DefaultUsageTemplate)
+	}
+
+	return a.usageForContextWithUsageRenderer(context, 2, RenderDefault)
 }
 
-// UsageForContextWithTemplate is the base usage function. You generally don't need to use this.
-func (a *Application) UsageForContextWithTemplate(context *ParseContext, indent int, tmpl string) error {
-	width := guessWidth(a.usageWriter)
-	funcs := template.FuncMap{
-		"Indent": func(level int) string {
-			return strings.Repeat(" ", level*indent)
-		},
-		"Wrap": func(indent int, s string) string {
-			buf := bytes.NewBuffer(nil)
-			indentText := strings.Repeat(" ", indent)
-			doc.ToText(buf, s, indentText, "  "+indentText, width-indent)
-			return buf.String()
-		},
-		"FormatFlag": formatFlag,
-		"FlagsToTwoColumns": func(f []*FlagModel) [][2]string {
-			rows := [][2]string{}
-			haveShort := false
-			for _, flag := range f {
-				if flag.Short != 0 {
-					haveShort = true
-					break
-				}
-			}
-			for _, flag := range f {
-				if !flag.Hidden {
-					rows = append(rows, [2]string{formatFlag(haveShort, flag), flag.HelpWithEnvar()})
-				}
-			}
-			return rows
-		},
-		"RequiredFlags": func(f []*FlagModel) []*FlagModel {
-			requiredFlags := []*FlagModel{}
-			for _, flag := range f {
-				if flag.Required {
-					requiredFlags = append(requiredFlags, flag)
-				}
-			}
-			return requiredFlags
-		},
-		"OptionalFlags": func(f []*FlagModel) []*FlagModel {
-			optionalFlags := []*FlagModel{}
-			for _, flag := range f {
-				if !flag.Required {
-					optionalFlags = append(optionalFlags, flag)
-				}
-			}
-			return optionalFlags
-		},
-		"ArgsToTwoColumns": func(a []*ArgModel) [][2]string {
-			rows := [][2]string{}
-			for _, arg := range a {
-				if !arg.Hidden {
-					var s string
-					if arg.PlaceHolder != "" {
-						s = arg.PlaceHolder
-					} else {
-						s = "<" + arg.Name + ">"
-					}
-					if !arg.Required {
-						s = "[" + s + "]"
-					}
-					rows = append(rows, [2]string{s, arg.HelpWithEnvar()})
-				}
-			}
-			return rows
-		},
-		"FormatTwoColumns": func(rows [][2]string) string {
-			buf := bytes.NewBuffer(nil)
-			formatTwoColumns(buf, indent, indent, width, rows)
-			return buf.String()
-		},
-		"FormatTwoColumnsWithIndent": func(rows [][2]string, indent, padding int) string {
-			buf := bytes.NewBuffer(nil)
-			formatTwoColumns(buf, indent, padding, width, rows)
-			return buf.String()
-		},
-		"FormatAppUsage":     formatAppUsage,
-		"FormatCommandUsage": formatCmdUsage,
-		"IsCumulative": func(value Value) bool {
-			r, ok := value.(remainderArg)
-			return ok && r.IsCumulative()
-		},
-		"Char": func(c rune) string {
-			return string(c)
-		},
-	}
-	for k, v := range a.usageFuncs {
-		funcs[k] = v
+// UsageForContextWithUsageRenderer renders usage without using text/template.
+// This is the fallback path when no UsageRenderer is set and the template doesn't match
+// a built-in renderer. Callers who want to avoid pulling in text/template should
+// use UsageRenderer or one of the built-in renderer constants.
+func (a *Application) UsageForContextWithUsageRenderer(context *ParseContext, indent int) error {
+	return a.usageForContextWithUsageRenderer(context, indent, a.usageRenderer)
+}
+
+func (a *Application) usageForContextWithUsageRenderer(context *ParseContext, indent int, fn UsageRenderer) error {
+	if fn == nil {
+		return errors.New("no usage renderer provided")
 	}
 
-	t, err := template.New("usage").Funcs(funcs).Parse(tmpl)
-	if err != nil {
-		return err
-	}
+	width := guessWidth(a.usageWriter)
 	var selectedCommand *CmdModel
 	if context.SelectedCommand != nil {
 		selectedCommand = context.SelectedCommand.Model()
 	}
-	ctx := templateContext{
-		App:   a.Model(),
-		Width: width,
-		Context: &templateParseContext{
+
+	return fn(a.usageWriter, &UsageContext{
+		App:    a.Model(),
+		Indent: indent,
+		Width:  width,
+		Context: &UsageParseContext{
 			SelectedCommand: selectedCommand,
 			FlagGroupModel:  context.flags.Model(),
 			ArgGroupModel:   context.arguments.Model(),
 		},
-	}
-	return t.Execute(a.usageWriter, ctx)
+	})
+}
+
+// UsageForContextWithTemplate renders usage using text/template for custom template strings.
+// This is the fallback path when no UsageRenderer is set. Callers who want to avoid pulling in text/template
+// should specify a UsageRenderer and call UsageForContextWithUsageRenderer instead.
+//
+// Note: calling this method directly will cause text/template to be linked into the binary.
+// For dead code elimination, prefer UsageRenderer with a UsageRenderer.
+func (a *Application) UsageForContextWithTemplate(context *ParseContext, indent int, tmpl string) error {
+
+	return templateRenderFunc(a, context, indent, tmpl)
 }

--- a/usage_renderer.go
+++ b/usage_renderer.go
@@ -1,0 +1,539 @@
+package kingpin
+
+import (
+	"bytes"
+	"fmt"
+	"go/doc"
+	"io"
+	"strings"
+)
+
+// UsageContext contains all data needed to render usage output.
+type UsageContext struct {
+	App     *ApplicationModel
+	Width   int
+	Indent  int
+	Context *UsageParseContext
+}
+
+// UsageParseContext contains parsed context for usage rendering.
+type UsageParseContext struct {
+	SelectedCommand *CmdModel
+	*FlagGroupModel
+	*ArgGroupModel
+}
+
+// UsageRenderer is a function that renders usage output programmatically.
+// Setting a UsageRenderer on an Application bypasses template-based rendering,
+// which avoids importing text/template and enables dead code elimination.
+type UsageRenderer func(w io.Writer, ctx *UsageContext) error
+
+// isCumulative checks if a Value is cumulative (repeatable).
+func isCumulative(value Value) bool {
+	r, ok := value.(interface{ IsCumulative() bool })
+	return ok && r.IsCumulative()
+}
+
+// WriteFormatCommand writes the flag summary and args portion of a command usage line.
+func WriteFormatCommand(w io.Writer, fg *FlagGroupModel, ag *ArgGroupModel) {
+	if fg != nil && len(fg.Flags) > 0 {
+		summary := fg.FlagSummary()
+		if summary != "" {
+			fmt.Fprintf(w, " %s", summary)
+		}
+	}
+
+	if ag == nil {
+		return
+	}
+
+	for _, arg := range ag.Args {
+		if arg.Hidden {
+			continue
+		}
+
+		name := "<" + arg.Name + ">"
+		if arg.PlaceHolder != "" {
+			name = arg.PlaceHolder
+		}
+		if isCumulative(arg.Value) {
+			name += "..."
+		}
+		if !arg.Required {
+			fmt.Fprintf(w, " [%s]", name)
+		} else {
+			fmt.Fprintf(w, " %s", name)
+		}
+	}
+}
+
+// WriteFormatUsage writes the usage line for a command or app, including the
+// flag summary, args, optional "<command> [<args> ...]" suffix, and help text.
+func WriteFormatUsage(w io.Writer, fg *FlagGroupModel, ag *ArgGroupModel, cg *CmdGroupModel, help string, wrapWidth int) {
+	WriteFormatCommand(w, fg, ag)
+	if cg != nil && len(cg.Commands) > 0 {
+		fmt.Fprint(w, " <command> [<args> ...]")
+	}
+	fmt.Fprintln(w)
+	if help != "" {
+		fmt.Fprintln(w)
+		buf := bytes.NewBuffer(nil)
+		doc.ToText(buf, help, "", preIndent, wrapWidth)
+		fmt.Fprint(w, buf.String())
+	}
+}
+
+// RenderDefault renders the standard usage output.
+func RenderDefault(w io.Writer, ctx *UsageContext) error {
+	width := ctx.Width
+
+	fmtTwoColumns := func(rows [][2]string) string {
+		var buf bytes.Buffer
+		FormatTwoColumns(&buf, ctx.Indent, ctx.Indent, width, rows)
+		return buf.String()
+	}
+
+	if ctx.Context.SelectedCommand != nil {
+		cmd := ctx.Context.SelectedCommand
+		fmt.Fprintf(w, "usage: %s %s", ctx.App.Name, cmd.String())
+		WriteFormatUsage(w, cmd.FlagGroupModel, cmd.ArgGroupModel, cmd.CmdGroupModel, cmd.Help, width)
+	} else {
+		fmt.Fprintf(w, "usage: %s", ctx.App.Name)
+		WriteFormatUsage(w, ctx.App.FlagGroupModel, ctx.App.ArgGroupModel, ctx.App.CmdGroupModel, ctx.App.Help, width)
+	}
+
+	fmt.Fprint(w, "\n\n")
+
+	if len(ctx.Context.Flags) > 0 {
+		fmt.Fprintln(w, "Flags:")
+		fmt.Fprint(w, fmtTwoColumns(FlagsToTwoColumns(ctx.Context.Flags)))
+		fmt.Fprintln(w)
+	}
+	if len(ctx.Context.Args) > 0 {
+		fmt.Fprintln(w, "Args:")
+		fmt.Fprint(w, fmtTwoColumns(ArgsToTwoColumns(ctx.Context.Args)))
+		fmt.Fprintln(w)
+	}
+
+	writeCommands := func(commands []*CmdModel) {
+		for _, cmd := range commands {
+			if cmd.Hidden {
+				continue
+			}
+
+			fmt.Fprint(w, cmd.FullCommand)
+			if cmd.Default {
+				fmt.Fprint(w, "*")
+			}
+			WriteFormatCommand(w, cmd.FlagGroupModel, cmd.ArgGroupModel)
+			fmt.Fprintln(w)
+			fmt.Fprint(w, Wrap(width, 4, cmd.Help))
+			fmt.Fprintln(w)
+		}
+	}
+
+	if ctx.Context.SelectedCommand != nil {
+		if ctx.Context.SelectedCommand.CmdGroupModel != nil && len(ctx.Context.SelectedCommand.Commands) > 0 {
+			fmt.Fprintln(w, "Subcommands:")
+			writeCommands(ctx.Context.SelectedCommand.FlattenedCommands())
+			fmt.Fprintln(w)
+		}
+	} else if ctx.App.CmdGroupModel != nil && len(ctx.App.Commands) > 0 {
+		fmt.Fprintln(w, "Commands:")
+		writeCommands(ctx.App.FlattenedCommands())
+		fmt.Fprintln(w)
+	}
+
+	return nil
+}
+
+// RenderSeparateOptionalFlags renders usage with required and optional flags listed separately.
+func RenderSeparateOptionalFlags(w io.Writer, ctx *UsageContext) error {
+	width := ctx.Width
+
+	fmtTwoColumns := func(rows [][2]string) string {
+		var buf bytes.Buffer
+		FormatTwoColumns(&buf, ctx.Indent, ctx.Indent, width, rows)
+		return buf.String()
+	}
+
+	requiredFlags := func(f []*FlagModel) []*FlagModel {
+		var out []*FlagModel
+		for _, flag := range f {
+			if flag.Required {
+				out = append(out, flag)
+			}
+		}
+		return out
+	}
+
+	optionalFlags := func(f []*FlagModel) []*FlagModel {
+		var out []*FlagModel
+		for _, flag := range f {
+			if !flag.Required {
+				out = append(out, flag)
+			}
+		}
+		return out
+	}
+
+	if ctx.Context.SelectedCommand != nil {
+		cmd := ctx.Context.SelectedCommand
+		fmt.Fprintf(w, "usage: %s %s", ctx.App.Name, cmd.String())
+		WriteFormatUsage(w, cmd.FlagGroupModel, cmd.ArgGroupModel, cmd.CmdGroupModel, cmd.Help, width)
+	} else {
+		fmt.Fprintf(w, "usage: %s", ctx.App.Name)
+		WriteFormatUsage(w, ctx.App.FlagGroupModel, ctx.App.ArgGroupModel, ctx.App.CmdGroupModel, ctx.App.Help, width)
+	}
+	fmt.Fprintln(w)
+
+	if ctx.Context.Flags != nil {
+		if rf := requiredFlags(ctx.Context.Flags); len(rf) > 0 {
+			fmt.Fprintln(w, "Required flags:")
+			fmt.Fprint(w, fmtTwoColumns(FlagsToTwoColumns(rf)))
+			fmt.Fprintln(w)
+		}
+		if of := optionalFlags(ctx.Context.Flags); len(of) > 0 {
+			fmt.Fprintln(w, "Optional flags:")
+			fmt.Fprint(w, fmtTwoColumns(FlagsToTwoColumns(of)))
+			fmt.Fprintln(w)
+		}
+	}
+	if len(ctx.Context.Args) > 0 {
+		fmt.Fprintln(w, "Args:")
+		fmt.Fprint(w, fmtTwoColumns(ArgsToTwoColumns(ctx.Context.Args)))
+		fmt.Fprintln(w)
+	}
+
+	writeCommands := func(commands []*CmdModel) {
+		for _, cmd := range commands {
+			if cmd.Hidden {
+				continue
+			}
+
+			fmt.Fprint(w, cmd.FullCommand)
+			if cmd.Default {
+				fmt.Fprint(w, "*")
+			}
+			WriteFormatCommand(w, cmd.FlagGroupModel, cmd.ArgGroupModel)
+			fmt.Fprintln(w)
+			fmt.Fprint(w, Wrap(width, 4, cmd.Help))
+			fmt.Fprintln(w)
+		}
+	}
+
+	if ctx.Context.SelectedCommand != nil {
+		fmt.Fprintln(w, "Subcommands:")
+		if ctx.Context.SelectedCommand.CmdGroupModel != nil && len(ctx.Context.SelectedCommand.Commands) > 0 {
+			writeCommands(ctx.Context.SelectedCommand.FlattenedCommands())
+			fmt.Fprintln(w)
+		}
+	} else if ctx.App.CmdGroupModel != nil && len(ctx.App.Commands) > 0 {
+		fmt.Fprintln(w, "Commands:")
+		writeCommands(ctx.App.FlattenedCommands())
+		fmt.Fprintln(w)
+	}
+
+	return nil
+}
+
+// RenderCompact renders usage with a hierarchical command list.
+func RenderCompact(w io.Writer, ctx *UsageContext) error {
+	width := ctx.Width
+
+	fmtTwoColumns := func(rows [][2]string) string {
+		var buf bytes.Buffer
+		FormatTwoColumns(&buf, ctx.Indent, ctx.Indent, width, rows)
+		return buf.String()
+	}
+
+	var writeCommandList func(commands []*CmdModel)
+	writeCommandList = func(commands []*CmdModel) {
+		for _, cmd := range commands {
+			if cmd.Hidden {
+				continue
+			}
+
+			fmt.Fprintf(w, "%s%s", strings.Repeat(" ", cmd.Depth*ctx.Indent), cmd.Name)
+			if cmd.Default {
+				fmt.Fprint(w, "*")
+			}
+			WriteFormatCommand(w, cmd.FlagGroupModel, cmd.ArgGroupModel)
+			fmt.Fprintln(w)
+			if cmd.CmdGroupModel != nil {
+				writeCommandList(cmd.Commands)
+			}
+		}
+	}
+
+	if ctx.Context.SelectedCommand != nil {
+		cmd := ctx.Context.SelectedCommand
+		fmt.Fprintf(w, "usage: %s %s", ctx.App.Name, cmd.String())
+		WriteFormatUsage(w, cmd.FlagGroupModel, cmd.ArgGroupModel, cmd.CmdGroupModel, cmd.Help, width)
+	} else {
+		fmt.Fprintf(w, "usage: %s", ctx.App.Name)
+		WriteFormatUsage(w, ctx.App.FlagGroupModel, ctx.App.ArgGroupModel, ctx.App.CmdGroupModel, ctx.App.Help, width)
+	}
+
+	fmt.Fprintln(w)
+
+	if len(ctx.Context.Flags) > 0 {
+		fmt.Fprintln(w, "Flags:")
+		fmt.Fprint(w, fmtTwoColumns(FlagsToTwoColumns(ctx.Context.Flags)))
+		fmt.Fprintln(w)
+	}
+	if len(ctx.Context.Args) > 0 {
+		fmt.Fprintln(w, "Args:")
+		fmt.Fprint(w, fmtTwoColumns(ArgsToTwoColumns(ctx.Context.Args)))
+		fmt.Fprintln(w)
+	}
+
+	if ctx.Context.SelectedCommand != nil {
+		if ctx.Context.SelectedCommand.CmdGroupModel != nil && len(ctx.Context.SelectedCommand.Commands) > 0 {
+			fmt.Fprintln(w, "Commands:")
+			fmt.Fprintf(w, "  %s\n", ctx.Context.SelectedCommand.String())
+			writeCommandList(ctx.Context.SelectedCommand.Commands)
+			fmt.Fprintln(w)
+		}
+	} else if ctx.App.CmdGroupModel != nil && len(ctx.App.Commands) > 0 {
+		fmt.Fprintln(w, "Commands:")
+		writeCommandList(ctx.App.Commands)
+		fmt.Fprintln(w)
+	}
+
+	return nil
+}
+
+// RenderManPage renders usage as a Unix man page.
+func RenderManPage(w io.Writer, ctx *UsageContext) error {
+	writeFormatFlags := func(fg *FlagGroupModel) {
+		if fg == nil {
+			return
+		}
+		for _, flag := range fg.Flags {
+			if flag.Hidden {
+				continue
+			}
+
+			fmt.Fprintln(w, ".TP")
+			fmt.Fprint(w, `\fB`)
+			if flag.Short != 0 {
+				fmt.Fprintf(w, "-%s, ", string(flag.Short))
+			}
+			fmt.Fprintf(w, "--%s", flag.Name)
+			if !flag.IsBoolFlag() {
+				fmt.Fprintf(w, "=%s", flag.FormatPlaceHolder())
+			}
+			fmt.Fprintln(w, `\fR`)
+			fmt.Fprintln(w, flag.Help)
+		}
+	}
+
+	// Header
+	fmt.Fprintf(w, ".TH %s 1 %s \"%s\"\n", ctx.App.Name, ctx.App.Version, ctx.App.Author)
+	fmt.Fprintln(w, `.SH "NAME"`)
+	fmt.Fprintln(w, ctx.App.Name)
+	fmt.Fprintln(w, `.SH "SYNOPSIS"`)
+	fmt.Fprintln(w, ".TP")
+	fmt.Fprintf(w, `\fB%s`, ctx.App.Name)
+	WriteFormatCommand(w, ctx.App.FlagGroupModel, ctx.App.ArgGroupModel)
+	if ctx.App.CmdGroupModel != nil && len(ctx.App.Commands) > 0 {
+		fmt.Fprint(w, " <command> [<args> ...]")
+	}
+	fmt.Fprintln(w, `\fR`)
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, `.SH "DESCRIPTION"`)
+	fmt.Fprintln(w, ctx.App.Help)
+	fmt.Fprintln(w, `.SH "OPTIONS"`)
+	writeFormatFlags(ctx.App.FlagGroupModel)
+
+	if ctx.App.CmdGroupModel != nil && len(ctx.App.Commands) > 0 {
+		fmt.Fprintln(w, `.SH "COMMANDS"`)
+		for _, cmd := range ctx.App.FlattenedCommands() {
+			if cmd.Hidden {
+				continue
+			}
+
+			fmt.Fprintln(w, ".SS")
+			fmt.Fprintf(w, `\fB%s`, cmd.FullCommand)
+			WriteFormatCommand(w, cmd.FlagGroupModel, cmd.ArgGroupModel)
+			fmt.Fprintln(w, `\fR`)
+			fmt.Fprintln(w, ".PP")
+			fmt.Fprintln(w, cmd.Help)
+			writeFormatFlags(cmd.FlagGroupModel)
+		}
+	}
+
+	return nil
+}
+
+// RenderLongHelp renders verbose usage with per-command flags.
+func RenderLongHelp(w io.Writer, ctx *UsageContext) error {
+	width := ctx.Width
+
+	fmtTwoColumns := func(rows [][2]string) string {
+		var buf bytes.Buffer
+		FormatTwoColumns(&buf, ctx.Indent, ctx.Indent, width, rows)
+		return buf.String()
+	}
+
+	fmt.Fprintf(w, "usage: %s", ctx.App.Name)
+	WriteFormatUsage(w, ctx.App.FlagGroupModel, ctx.App.ArgGroupModel, ctx.App.CmdGroupModel, ctx.App.Help, width)
+	fmt.Fprintln(w)
+
+	if len(ctx.Context.Flags) > 0 {
+		fmt.Fprintln(w, "Flags:")
+		fmt.Fprint(w, fmtTwoColumns(FlagsToTwoColumns(ctx.Context.Flags)))
+		fmt.Fprintln(w)
+	}
+	if len(ctx.Context.Args) > 0 {
+		fmt.Fprintln(w, "Args:")
+		fmt.Fprint(w, fmtTwoColumns(ArgsToTwoColumns(ctx.Context.Args)))
+		fmt.Fprintln(w)
+	}
+
+	if ctx.App.CmdGroupModel != nil && len(ctx.App.Commands) > 0 {
+		fmt.Fprintln(w, "Commands:")
+		for _, cmd := range ctx.App.FlattenedCommands() {
+			if cmd.Hidden {
+				continue
+			}
+
+			fmt.Fprint(w, cmd.FullCommand)
+			WriteFormatCommand(w, cmd.FlagGroupModel, cmd.ArgGroupModel)
+			fmt.Fprintln(w)
+			fmt.Fprint(w, Wrap(width, 4, cmd.Help))
+			if cmd.FlagGroupModel != nil {
+				rows := FlagsToTwoColumns(cmd.Flags)
+				if len(rows) > 0 {
+					var buf bytes.Buffer
+					FormatTwoColumns(&buf, 4, 2, width, rows)
+					fmt.Fprint(w, buf.String())
+				}
+			}
+			fmt.Fprint(w, "\n\n")
+		}
+		fmt.Fprint(w, "\n")
+	}
+
+	return nil
+}
+
+// RenderBashCompletion renders a bash completion script.
+func RenderBashCompletion(w io.Writer, ctx *UsageContext) error {
+	name := ctx.App.Name
+	_, err := fmt.Fprintf(w, `
+_%[1]s_bash_autocomplete() {
+    local cur prev opts base
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    opts=$( ${COMP_WORDS[0]} --completion-bash "${COMP_WORDS[@]:1:$COMP_CWORD}" )
+    COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+    return 0
+}
+complete -F _%[1]s_bash_autocomplete -o default %[1]s
+
+`, name)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// RenderZshCompletion renders a zsh completion script.
+func RenderZshCompletion(w io.Writer, ctx *UsageContext) error {
+	name := ctx.App.Name
+	_, err := fmt.Fprintf(w, `#compdef %[1]s
+
+_%[1]s() {
+    local matches=($(${words[1]} --completion-bash "${(@)words[2,$CURRENT]}"))
+    compadd -a matches
+
+    if [[ $compstate[nmatches] -eq 0 && $words[$CURRENT] != -* ]]; then
+        _files
+    fi
+}
+
+if [[ "$(basename -- ${(%%):-%%x})" != "_%[1]s" ]]; then
+    compdef _%[1]s %[1]s
+fi
+`, name)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func RenderFishCompletion(w io.Writer, ctx *UsageContext) error {
+	name := ctx.App.Name
+	_, err := fmt.Fprintf(w, `complete -c %[1]s -f -a '(
+    set -l tokens (commandline -xpc)
+    set -l current (commandline -ct)
+    set -l completions (%[1]s --completion-bash $tokens[2..] $current)
+    if test -n "$completions"
+        printf "%%s\n" $completions
+    else
+        __fish_complete_path $current
+    end
+)'
+`, name)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// FlagsToTwoColumns converts a slice of flags into two-column row data
+// suitable for FormatTwoColumns. Hidden flags are excluded.
+func FlagsToTwoColumns(f []*FlagModel) [][2]string {
+	var rows [][2]string
+	haveShort := ShortFlagsPresent(f)
+	for _, flag := range f {
+		if !flag.Hidden {
+			rows = append(rows, [2]string{FormatFlag(haveShort, flag), flag.HelpWithEnvar()})
+		}
+	}
+	return rows
+}
+
+// ArgsToTwoColumns converts a slice of args into two-column row data
+// suitable for FormatTwoColumns. Hidden args are excluded.
+func ArgsToTwoColumns(a []*ArgModel) [][2]string {
+	var rows [][2]string
+	for _, arg := range a {
+		if arg.Hidden {
+			continue
+		}
+
+		s := "<" + arg.Name + ">"
+		if arg.PlaceHolder != "" {
+			s = arg.PlaceHolder
+		}
+		if !arg.Required {
+			s = "[" + s + "]"
+		}
+		rows = append(rows, [2]string{s, arg.HelpWithEnvar()})
+	}
+	return rows
+}
+
+// Wrap wraps text at the given width with the given indent level, using go/doc formatting.
+func Wrap(width, indent int, s string) string {
+	var buf bytes.Buffer
+	indentText := strings.Repeat(" ", indent)
+	doc.ToText(&buf, s, indentText, "  "+indentText, width-indent)
+	return buf.String()
+}
+
+// ShortFlagsPresent checks if any flags in the slice have a short form.
+func ShortFlagsPresent(f []*FlagModel) bool {
+	for _, flag := range f {
+		if flag.Short != 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/usage_template.go
+++ b/usage_template.go
@@ -1,0 +1,100 @@
+package kingpin
+
+import (
+	"bytes"
+	"strings"
+	"text/template"
+)
+
+// templateRenderFunc executes usage rendering via text/template.
+// This function is stored in Application.templateRenderer when
+// UsageTemplate() or UsageFuncs() is called, ensuring that text/template
+// is only linked into the binary when templates are actually used.
+// Programs that only call UsageRenderer will not reference this function,
+// allowing the linker to eliminate text/template and its reflect.MethodByName dependency.
+func templateRenderFunc(a *Application, context *ParseContext, indent int, tmpl string) error {
+	width := guessWidth(a.usageWriter)
+	var selectedCommand *CmdModel
+	if context.SelectedCommand != nil {
+		selectedCommand = context.SelectedCommand.Model()
+	}
+	ctx := &UsageContext{
+		App:   a.Model(),
+		Width: width,
+		Context: &UsageParseContext{
+			SelectedCommand: selectedCommand,
+			FlagGroupModel:  context.flags.Model(),
+			ArgGroupModel:   context.arguments.Model(),
+		},
+	}
+
+	funcs := template.FuncMap{
+		"Indent": func(level int) string {
+			return strings.Repeat(" ", level*indent)
+		},
+		"Wrap": func(indent int, s string) string {
+			return Wrap(width, indent, s)
+		},
+		"FormatFlag":        FormatFlag,
+		"FormatFlagCompact": FormatFlagCompact,
+		"FlagsToTwoColumnsCompact": func(f []*FlagModel) [][2]string {
+			var rows [][2]string
+			haveShort := ShortFlagsPresent(f)
+			for _, flag := range f {
+				if !flag.Hidden {
+					rows = append(rows, [2]string{FormatFlagCompact(haveShort, flag), flag.Help})
+				}
+			}
+			return rows
+		},
+		"FlagsToTwoColumns": FlagsToTwoColumns,
+		"RequiredFlags": func(f []*FlagModel) []*FlagModel {
+			var out []*FlagModel
+			for _, flag := range f {
+				if flag.Required {
+					out = append(out, flag)
+				}
+			}
+			return out
+		},
+		"OptionalFlags": func(f []*FlagModel) []*FlagModel {
+			var out []*FlagModel
+			for _, flag := range f {
+				if !flag.Required {
+					out = append(out, flag)
+				}
+			}
+			return out
+		},
+		"ArgsToTwoColumns": ArgsToTwoColumns,
+		"FormatTwoColumns": func(rows [][2]string) string {
+			var buf bytes.Buffer
+			FormatTwoColumns(&buf, indent, 2, width, rows)
+			return buf.String()
+		},
+		"FormatTwoColumnsWithIndent": func(rows [][2]string, indent, padding int) string {
+			var buf bytes.Buffer
+			FormatTwoColumns(&buf, indent, padding, width, rows)
+			return buf.String()
+		},
+		"FormatAppUsage":     formatAppUsage,
+		"FormatCommandUsage": formatCmdUsage,
+		"IsCumulative": func(value Value) bool {
+			r, ok := value.(repeatableFlag)
+			return ok && r.IsCumulative()
+		},
+		"Char": func(c rune) string {
+			return string(c)
+		},
+	}
+	for k, v := range a.usageFuncs {
+		funcs[k] = v
+	}
+
+	t, err := template.New("usage").Funcs(funcs).Parse(tmpl)
+	if err != nil {
+		return err
+	}
+
+	return t.Execute(a.usageWriter, ctx)
+}

--- a/usage_test.go
+++ b/usage_test.go
@@ -2,16 +2,19 @@ package kingpin
 
 import (
 	"bytes"
+	"fmt"
+	"io"
 	"strings"
 	"testing"
 	"text/template"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFormatTwoColumns(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
-	formatTwoColumns(buf, 2, 2, 20, [][2]string{
+	FormatTwoColumns(buf, 2, 2, 20, [][2]string{
 		{"--hello", "Hello world help with something that is cool."},
 	})
 	expected := `  --hello  Hello
@@ -29,7 +32,7 @@ func TestFormatTwoColumnsWide(t *testing.T) {
 		{strings.Repeat("x", 29), "29 chars"},
 		{strings.Repeat("x", 30), "30 chars"}}
 	buf := bytes.NewBuffer(nil)
-	formatTwoColumns(buf, 0, 0, 200, samples)
+	FormatTwoColumns(buf, 0, 0, 200, samples)
 	expected := `xxxxxxxxxxxxxxxxxxxxxxxxxxxxx29 chars
 xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
                              30 chars
@@ -38,30 +41,65 @@ xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 }
 
 func TestHiddenCommand(t *testing.T) {
-	templates := []struct{ name, template string }{
-		{"default", DefaultUsageTemplate},
-		{"Compact", CompactUsageTemplate},
-		{"Long", LongHelpTemplate},
-		{"Man", ManPageTemplate},
+	templates := []struct {
+		name     string
+		template string
+		renderer UsageRenderer
+	}{
+		{
+			name:     "default template",
+			template: DefaultUsageTemplate,
+		},
+		{
+			name:     "default renderer",
+			renderer: RenderDefault,
+		},
+		{
+			name:     "Compact template",
+			template: CompactUsageTemplate,
+		},
+		{
+			name:     "Compact renderer",
+			renderer: RenderCompact,
+		},
+		{
+			name:     "Long template",
+			template: LongHelpTemplate,
+		},
+		{
+			name:     "Long renderer",
+			renderer: RenderLongHelp,
+		},
+		{
+			name:     "Man template",
+			template: ManPageTemplate,
+		},
+		{
+			name:     "Man renderer",
+			template: ManPageTemplate,
+		},
 	}
 
-	var buf bytes.Buffer
-	t.Log("1")
-
-	a := New("test", "Test").Writer(&buf).Terminate(nil)
-	a.Command("visible", "visible")
-	a.Command("hidden", "hidden").Hidden()
-
 	for _, tp := range templates {
-		buf.Reset()
-		a.UsageTemplate(tp.template)
-		a.Parse(nil)
-		// a.Parse([]string{"--help"})
-		usage := buf.String()
-		t.Logf("Usage for %s is:\n%s\n", tp.name, usage)
+		t.Run(tp.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			a := New("test", "Test").Writer(&buf).Terminate(nil)
+			a.Command("visible", "visible")
+			a.Command("hidden", "hidden").Hidden()
+			if tp.template != "" {
+				a.UsageTemplate(tp.template)
+			}
+			if tp.renderer != nil {
+				a.UsageRenderer(tp.renderer)
+			}
+			_, err := a.Parse(nil)
+			require.ErrorIs(t, err, ErrCommandNotSpecified)
+			usage := buf.String()
+			t.Logf("Usage for %s is:\n%s\n", tp.name, usage)
 
-		assert.NotContains(t, usage, "hidden")
-		assert.Contains(t, usage, "visible")
+			assert.NotContains(t, usage, "hidden")
+			assert.Contains(t, usage, "visible")
+		})
 	}
 }
 
@@ -73,9 +111,66 @@ func TestUsageFuncs(t *testing.T) {
 	a.UsageFuncs(template.FuncMap{
 		"add": func(x, y int) int { return x + y },
 	})
-	a.Parse([]string{"--help"})
+	_, err := a.Parse([]string{"--help"})
+	require.NoError(t, err)
 	usage := buf.String()
 	assert.Equal(t, "3", usage)
+
+	buf.Reset()
+	a = New("test", "Test help").UsageWriter(&buf).Terminate(nil)
+	a.UsageFuncs(map[string]interface{}{
+		"Wrap": func(indent int, s string) string { return "OVERRIDDEN\n" },
+	})
+
+	_, err = a.Parse([]string{"--help"})
+	require.NoError(t, err)
+	usage = buf.String()
+	assert.Contains(t, usage, "OVERRIDDEN")
+}
+
+func TestUsageFuncsApplyToHiddenFlagPaths(t *testing.T) {
+	for _, tp := range []struct {
+		name string
+		flag string
+	}{
+		{
+			name: "help-long",
+			flag: "--help-long",
+		},
+		{
+			name: "help-man",
+			flag: "--help-man",
+		},
+	} {
+		t.Run(tp.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			a := New("test", "Test help").HiddenHelpWriter(&buf).Terminate(nil)
+			a.Flag("verbose", "Verbose output.").Short('v').Bool()
+			a.UsageFuncs(map[string]interface{}{
+				"Wrap": func(indent int, s string) string { return "OVERRIDDEN\n" },
+				"Char": func(c rune) string { return "OVERRIDDEN" },
+			})
+
+			_, err := a.Parse([]string{tp.flag})
+			require.NoError(t, err)
+
+			assert.Contains(t, buf.String(), "OVERRIDDEN")
+		})
+	}
+}
+
+func TestUsageRenderer(t *testing.T) {
+	var buf bytes.Buffer
+	a := New("test", "Test").Writer(&buf).Terminate(nil)
+	a.UsageRenderer(func(w io.Writer, ctx *UsageContext) error {
+		_, err := fmt.Fprintf(w, "custom: %s", ctx.App.Name)
+		return err
+	})
+
+	_, err := a.Parse([]string{"--help"})
+	require.NoError(t, err)
+	usage := buf.String()
+	assert.Equal(t, "custom: test", usage)
 }
 
 func TestCmdClause_HelpLong(t *testing.T) {
@@ -87,7 +182,8 @@ func TestCmdClause_HelpLong(t *testing.T) {
 	a.UsageTemplate(tpl)
 	a.Command("command", "short help text").HelpLong("long help text")
 
-	a.Parse([]string{"command", "--help"})
+	_, err := a.Parse([]string{"command", "--help"})
+	require.NoError(t, err)
 	usage := buf.String()
 	assert.Equal(t, "long help text", usage)
 }
@@ -99,8 +195,162 @@ func TestArgEnvVar(t *testing.T) {
 	a.Arg("arg", "Enable arg").Envar("ARG").String()
 	a.Flag("flag", "Enable flag").Envar("FLAG").String()
 
-	a.Parse([]string{"command", "--help"})
+	_, err := a.Parse([]string{"command", "--help"})
+	require.NoError(t, err)
 	usage := buf.String()
 	assert.Contains(t, usage, "($ARG)")
 	assert.Contains(t, usage, "($FLAG)")
+}
+
+func TestRendererPrioritizedWhenUsageFuncsSet(t *testing.T) {
+	var buf bytes.Buffer
+	a := New("test", "Test").UsageWriter(&buf).Terminate(nil)
+	a.UsageFuncs(map[string]interface{}{
+		"Wrap": func(indent int, s string) string { return "FROM_TEMPLATE\n" },
+	})
+	a.UsageRenderer(func(w io.Writer, ctx *UsageContext) error {
+		_, err := fmt.Fprint(w, "FROM_RENDERER")
+		return err
+	})
+
+	_, err := a.Parse([]string{"--help"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "FROM_RENDERER", buf.String())
+
+}
+
+func TestUsageRendererDoesNotOverrideHiddenFlags(t *testing.T) {
+	flags := []string{"--help-long", "--help-man", "--completion-script-bash", "--completion-script-zsh", "--completion-script-fish"}
+
+	for _, flag := range flags {
+		t.Run(flag, func(t *testing.T) {
+			var buf bytes.Buffer
+			a := New("test", "Test help").HiddenHelpWriter(&buf).Terminate(nil)
+			a.UsageRenderer(func(w io.Writer, ctx *UsageContext) error {
+				_, err := fmt.Fprint(w, "CUSTOM_HELP")
+				return err
+			})
+
+			_, err := a.Parse([]string{flag})
+			require.NoError(t, err)
+
+			assert.NotContains(t, buf.String(), "CUSTOM_HELP")
+			assert.NotEmpty(t, buf.String())
+		})
+	}
+}
+
+func TestUsageTemplatePreferredOverUsageRenderer(t *testing.T) {
+	var buf bytes.Buffer
+	a := New("test", "Test").UsageWriter(&buf).Terminate(nil)
+	a.UsageTemplate("TEMPLATE:{{ .App.Name }}")
+	a.UsageRenderer(func(w io.Writer, ctx *UsageContext) error {
+		_, err := fmt.Fprint(w, "FROM_RENDERER")
+		return err
+	})
+
+	_, err := a.Parse([]string{"--help"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "TEMPLATE:test", buf.String())
+}
+
+func TestRenderersMatchTemplates(t *testing.T) {
+	tests := []struct {
+		name     string
+		renderer UsageRenderer
+		template string
+	}{
+		{
+			name:     "default",
+			renderer: RenderDefault,
+			template: DefaultUsageTemplate,
+		},
+		{
+			name:     "separate-optional-flags",
+			renderer: RenderSeparateOptionalFlags,
+			template: SeparateOptionalFlagsUsageTemplate,
+		},
+		{
+			name:     "compact",
+			renderer: RenderCompact,
+			template: CompactUsageTemplate,
+		},
+		{
+			name:     "long-help",
+			renderer: RenderLongHelp,
+			template: LongHelpTemplate,
+		},
+		{
+			name:     "man-page",
+			renderer: RenderManPage,
+			template: ManPageTemplate,
+		},
+		{
+			name:     "bash-completion",
+			renderer: RenderBashCompletion,
+			template: BashCompletionTemplate,
+		},
+		{
+			name:     "zsh-completion",
+			renderer: RenderZshCompletion,
+			template: ZshCompletionTemplate,
+		},
+		{
+			name:     "fish-completion",
+			renderer: RenderFishCompletion,
+			template: FishCompletionTemplate,
+		},
+	}
+
+	contexts := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "root",
+			args: nil,
+		},
+		{
+			name: "nested-command",
+			args: []string{"sub", "nested"},
+		},
+	}
+
+	for _, test := range tests {
+		for _, context := range contexts {
+			t.Run(test.name+"/"+context.name, func(t *testing.T) {
+				var templateBuf, rendererBuf bytes.Buffer
+				makeApp := func(w *bytes.Buffer) *Application {
+					a := New("test", "A test application.").UsageWriter(w).Terminate(nil).Version("1.0").Author("Test Author")
+					a.Flag("verbose", "Enable verbose output.").Short('v').Bool()
+					a.Flag("config", "Path to config file.").String()
+
+					sub := a.Command("sub", "A subcommand.")
+					sub.Flag("count", "Number of items.").Int()
+
+					nested := sub.Command("nested", "A nested command.")
+					nested.Arg("file", "File to process.").String()
+
+					a.Command("other", "Another command.")
+					return a
+				}
+
+				appT := makeApp(&templateBuf)
+				ctx, err := appT.ParseContext(context.args)
+				require.NoError(t, err)
+				err = appT.UsageForContextWithTemplate(ctx, 2, test.template)
+				require.NoError(t, err)
+
+				appR := makeApp(&rendererBuf)
+				ctx, err = appR.ParseContext(context.args)
+				require.NoError(t, err)
+				err = appR.usageForContextWithUsageRenderer(ctx, 2, test.renderer)
+				require.NoError(t, err)
+
+				assert.Equal(t, templateBuf.String(), rendererBuf.String())
+			})
+		}
+	}
 }


### PR DESCRIPTION
This was largely inspired by https://github.com/spf13/cobra/pull/1956.

The usage rendering relied on text/template which in turn relied on reflect.MethodByName. As a result, Go's deadcode elimination is prevented from running, and thus means any downstream consumers of kingpin also cannot take advantage of deadcode elimination.

This changes the usage rendering of kingpin such that text/template is not used by default. The existing templates were converted into pure Go functions, and an extensive test suite was added to ensure equality with the legacy templates. Default applications now use the pure Go equivalent of kingpin.DefaultUsageTemplate. The existing UsageTemplate and UsageFuncs APIs remain intact to preserve compatibility. Any use of either API will result in text/template rendering usage and preventing deadcode elimination.

The basic app used in TestDeadCodeElimination was tested before and after this change. The usage text remained the same, but the binary size shrunk from ~5MB to ~2MB.