### PR TITLE
fix: correct typos in comments and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ $ go get gopkg.in/alecthomas/kingpin.v1
 
 - *2014-06-27* -- Stable v1.1.0 release.
     - Bug fixes.
-    - Always return an error (rather than panicing) when misconfigured.
+    - Always return an error (rather than panicking) when misconfigured.
     - `OpenFile(flag, perm)` value type added, for finer control over opening files.
     - Significantly improved usage formatting.
 

--- a/app.go
+++ b/app.go
@@ -31,7 +31,7 @@ type Application struct {
 	version          string
 	errorWriter      io.Writer // Destination for errors.
 	usageWriter      io.Writer // Destination for usage
-	hiddenHelpWriter io.Writer // Desitination for hidden help commands.
+	hiddenHelpWriter io.Writer // Destination for hidden help commands.
 	usageTemplate    string
 	usageFuncs       map[string]interface{}
 	templateRenderer func(a *Application, context *ParseContext, indent int, tmpl string) error
@@ -703,7 +703,7 @@ func (a *Application) completionOptions(context *ParseContext) []string {
 
 		if strings.HasPrefix(prevArg, "--") && !strings.HasPrefix(currArg, "--") {
 			// Matches: 	./myApp --flag value
-			// Wont Match: 	./myApp --flag --
+			// Won't Match: 	./myApp --flag --
 			flagName = prevArg[2:] // Strip the "--"
 			flagValue = currArg
 		} else if strings.HasPrefix(currArg, "--") {


### PR DESCRIPTION
Fix three small typos found in comments and README:

- `README.md`: "panicing" -> "panicking" (changelog entry)
- `app.go` line 34: "Desitination" -> "Destination" (struct field comment)
- `app.go` line 706: "Wont" -> "Won't" (inline completion logic comment)

All three are straightforward spelling errors with no functional impact.